### PR TITLE
write out a lookup table for comids

### DIFF
--- a/R/make_mainstems.R
+++ b/R/make_mainstems.R
@@ -1,9 +1,9 @@
 # to run interactively, use:
-old_ms <- tar_read("mainstems_v1")
-new_ms <- tar_read("mainstems_v2")
-old_net <- tar_read("enhd_v1")
-new_net <- tar_read("enhd_v2")
-changes <- tar_read("reconciled_mainstems")
+# old_ms <- tar_read("mainstems_v1")
+# new_ms <- tar_read("mainstems_v2")
+# old_net <- tar_read("enhd_v1")
+# new_net <- tar_read("enhd_v2")
+# changes <- tar_read("reconciled_mainstems")
 
 make_mainstems <- function(old_ms, new_ms, old_net, new_net, changes, out_f) {
   old_ms <- sf::read_sf(old_ms)
@@ -141,19 +141,19 @@ make_mainstems <- function(old_ms, new_ms, old_net, new_net, changes, out_f) {
            downstream_mainstem_id = ifelse(!is.na(down_mainstem_id), 
                                            paste0("https://geoconnex.us/ref/mainstems/", down_mainstem_id),
                                            down_mainstem_id),
-           head_nhdpv2_COMID = ifelse(is.na(head_nhdpv2_COMID), NA, 
+           head_nhdpv2_COMID = ifelse(is.na(head_nhdpv2_COMID), "", 
                                       paste0("https://geoconnex.us/nhdplusv2/comid/", head_nhdpv2_COMID)),
-           outlet_nhdpv2_COMID = ifelse(is.na(outlet_nhdpv2_COMID), NA, 
+           outlet_nhdpv2_COMID = ifelse(is.na(outlet_nhdpv2_COMID), "", 
                                         paste0("https://geoconnex.us/nhdplusv2/comid/", outlet_nhdpv2_COMID)),
-           head_nhdpv2HUC12 = ifelse(is.na(head_nhdpv2HUC12), NA, 
+           head_nhdpv2HUC12 = ifelse(is.na(head_nhdpv2HUC12), "", 
                                      paste0("https://geoconnex.us/nhdplusv2/huc12/", head_nhdpv2HUC12)),
-           outlet_nhdpv2HUC12 = ifelse(is.na(outlet_nhdpv2HUC12), NA, 
+           outlet_nhdpv2HUC12 = ifelse(is.na(outlet_nhdpv2HUC12), "", 
                                        paste0("https://geoconnex.us/nhdplusv2/huc12/", outlet_nhdpv2HUC12)),
            lengthkm = round(length, digits = 1),
            outlet_drainagearea_sqkm = round(totdasqkm, digits = 1),
-           new_mainstemid = sapply(unname(new_mainstemid), paste, collapse = ", "),
+           new_mainstemid = unname(sapply(new_mainstemid, paste, collapse = ", ")),
            superseded = ifelse(is.na(superseded), FALSE, superseded)) |>
-    mutate(new_mainstemid = unname(ifelse(new_mainstemid == "", NULL, new_mainstemid))) |>
+    mutate(new_mainstemid = ifelse(new_mainstemid == "NA", "", new_mainstemid)) |>
     select(id = mainstem_id, uri,
            featuretype = type,
            downstream_mainstem_id,
@@ -168,6 +168,8 @@ make_mainstems <- function(old_ms, new_ms, old_net, new_net, changes, out_f) {
            head_2020HUC12, outlet_2020HUC12,
            superseded, new_mainstemid) %>%
     mutate(id = as.character(id))
+  
+    ms_out <- mutate_if(ms_out, is.character, ~tidyr::replace_na(.,""))
   
   ms_out <- sf::st_transform(ms_out, 4326)
   

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -1,0 +1,29 @@
+tar_load("mainstems")
+tar_load("enhd_v2")
+
+write_lookups <- function(mainstems, enhd_v2) {
+  enhd_v2 <- arrow::read_parquet(enhd_v2)
+  
+  out <- sf::st_drop_geometry(mainstems) |>
+    filter(!superseded) |>
+    select(uri, head_nhdpv2_COMID, outlet_nhdpv2_COMID) |>
+    mutate(head_nhdpv2_COMID = as.numeric(gsub("https://geoconnex.us/nhdplusv2/comid/",
+                                               "",
+                                               head_nhdpv2_COMID)),
+           outlet_nhdpv2_COMID = as.numeric(gsub("https://geoconnex.us/nhdplusv2/comid/",
+                                               "",
+                                               outlet_nhdpv2_COMID))) |>
+    left_join(distinct(select(enhd_v2, comid, levelpathi)),
+              by = c("head_nhdpv2_COMID" = "comid")) |>
+    left_join(distinct(select(enhd_v2, comid, levelpathi)),
+              by = "levelpathi")
+  
+  out <- group_by(out, levelpathi) |>
+    mutate(outlet_check = any(comid == outlet_nhdpv2_COMID))
+  
+  if(any(!out$outlet_check)) stop("all levelpaths should have the outlet in them")
+  
+  out <- select(ungroup(out), uri, comid)  
+
+  readr::write_csv(out, "out/nhdpv2_lookup.csv")
+}

--- a/_targets.R
+++ b/_targets.R
@@ -46,6 +46,7 @@ list(
                                                         enhd_v2,
                                                         reconciled_mainstems,
                                                         "out/mainstems.gpkg")),
+  tar_target(name = lookup, command = write_lookups(mainstems, enhd_v2)),
   tar_target(name = registry, command = build_registry(mainstems, 
                                                        registry = registry_file,
                                                        providers = provider_file)),


### PR DESCRIPTION
This incorporates an output file that provides a lookup between comids along the published mainstem ids and the mainstem uris. It will be added as a release artifact to a 2.1 release.