### PR TITLE
V3.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,15 @@
-reference mainstems v3.1.1
+reference mainstems v3.2
 ========================
 
-v3.1.1 is a minor patch that updates the nhdphr_lookup.csv output file. No other changes occurred.
+v3.2 improves the nhdplushr_lookup.csv output and fixes several issues:
+
+- Fix topo_sort bug related to HR representations
+- Fix missing nhdplushr head/outlet entries (#18)
+- Patch missing HR mainstems in lookup (#18)
+- Improve handling of duplicates and cross-region lookups
+- Fix major cross-domain river outlet ids (#22)
+- Update nhdplushr outlet ids (#21)
+- Add validation checks
 
 reference mainstems v3.1
 ========================

--- a/R/make_mainstems.R
+++ b/R/make_mainstems.R
@@ -84,6 +84,8 @@ initialize_mainstems <- function(enhd_v3, ref_rivers, new_net, hr_net, changes) 
   # Extract distinct downstream mainstem relationships, resolving duplicates and validating connectivity.
   new_dm <- get_new_dm(new_net_nolp, enhd_v3)
 
+  changes$add <- fix_hr_outlets(changes$add, new_net, readr::read_csv("data/review/drop_diverted_outlet.csv", col_types = "ccc"))
+
   # Reconcile superseded, kept, deprecated, added, and replaced mainstems into a unified output dataset.
   ms_out_1 <- get_ms_out(ref_rivers, changes)
 
@@ -118,6 +120,47 @@ initialize_mainstems <- function(enhd_v3, ref_rivers, new_net, hr_net, changes) 
   ms_out$outlet_nhdpv2_COMID[ms_out$uri == "https://geoconnex.us/ref/mainstems/2183898"] <- ""
 
   ms_out
+}
+
+# we have a bunch of lp mainstems (nhdplusv2) that span multiple levelpaths (nhdplushr)
+# the outlet of the top levelpath needs to be the outlet of the lp mainstem
+fix_hr_outlets <- function(adds, new_net, to_fix) {
+
+  # the complete paths we need to look at
+  paths <- filter(new_net, lp_mainstem_v3 %in% to_fix$lp_mainstem_v3)
+
+  # make sure we have everything we need
+  stopifnot(all(to_fix$lp_mainstem_v3 %in% paths$lp_mainstem_v3))
+  stopifnot(all(to_fix$levelpath_unique %in% paths$levelpath))
+
+  # expect more levelpaths
+  stopifnot(length(unique(paths$levelpath)) > length(unique(paths$lp_mainstem_v3)))
+
+  paths2 <- sf::st_drop_geometry(paths) |>
+    # type conversion for join
+    mutate(lp_mainstem_v3 = as.numeric(lp_mainstem_v3)) |>
+    # join incoming mainstems to get head and outlet id
+    left_join(select(sf::st_drop_geometry(adds), lp_mainstem_v3, head_nhdplushr_id, outlet_nhdplushr_id), by = "lp_mainstem_v3") |>
+    # group by the path we want a new outlet for
+    group_by(levelpath) |>
+    # we only care about the levelpath with the lpv3 head
+    mutate(has_head = any(gsub("nhdphr-", "", id) == head_nhdplushr_id)) |>
+    # filter so we only have what we need
+    filter(has_head)
+  
+  # expect one levelpath per lpv3
+  stopifnot(length(unique(paths2$levelpath)) == length(unique(paths2$lp_mainstem_v3)))
+
+  paths2 <- paths2 |>
+    mutate(head_nhdplushr_id_check = gsub("nhdphr-", "", id[1]), outlet_nhdplushr_id = gsub("nhdphr-", "", id[n()]))
+
+  # sanity check that the heads were the same
+  stopifnot(all(paths2$head_nhdplushr_id_check == paths2$head_nhdplushr_id))
+
+  paths2 <- select(ungroup(paths2), lp_mainstem_v3, outlet_nhdplushr_id) |>
+    distinct()
+
+  dplyr::rows_update(as.data.frame(adds), paths2, by = "lp_mainstem_v3") |> sf::st_sf()
 }
 
 #' Write the lp_mainstem_v3 Lookup Table
@@ -376,6 +419,9 @@ validate_mainstems <- function(ms_out) {
 
   # more lenient on drainage area
   stopifnot(all(is.na(ms_out$outlet_drainagearea_sqkm) | (ms_out$outlet_drainagearea_sqkm >= 0 & ms_out$outlet_drainagearea_sqkm < 3e6)))
+
+  # "nhdpv2" can not appear in the nhdplushr head and outlet ids
+  stopifnot(!any(grepl("nhdpv2", ms_out$head_nhdplushr_id) | grepl("nhdpv2", ms_out$outlet_nhdplushr_id)))
 
   TRUE
 }
@@ -855,10 +901,38 @@ add_hr_mainstems <- function(ms_out, new_net, nhdphr_source_extra, changes) {
 
   stopifnot(all(is.na(check$uri) | check$uri == check$uri_update))
 
+  # need to check that the tonode is the fromnode of the feature that toid indicates
+  # some cross vpu connections have messed up from/tonode entries
+  nhdphr_source <- nhdphr_source |>
+    left_join(select(
+      sf::st_drop_geometry(nhdphr_source), id, tonode_update = fromnode
+    ), by = c("toid" = "id"))
+
+  # just being super careful -- see https://code.usgs.gov/wma/nhgf/reference-fabric/reference-network/-/issues/16
+  stopifnot(nhdphr_source$lp_mainstem_v3[
+    !is.na(nhdphr_source$tonode) & 
+      !is.na(nhdphr_source$tonode_update) & 
+      nhdphr_source$tonode != nhdphr_source$tonode_update
+  ] == c(148852, 148852, 148774, 1009084, 2208010, 2204387))
+
+  nhdphr_source <- nhdphr_source |>
+    mutate(tonode = ifelse(!is.na(tonode_update) & tonode_update != tonode, tonode_update, tonode)) |>
+    select(-tonode_update)
+
+  update_topo_sort <- select(sf::st_drop_geometry(nhdphr_source), id, fromnode, tonode, divergence) |>
+    hydroloom::add_toids(return_dendritic = FALSE) |>
+    hydroloom::add_topo_sort() |>
+    select(id, topo_sort) |>
+    distinct()
+
+  stopifnot(!any(duplicated(update_topo_sort$id)))
+
   # Sort flowlines headwater-first (desc topo_sort) so collapse_lines produces
   # a directed LineString flowing toward the outlet. Group by mainstem and
   # split into 80 work chunks for balanced parallel processing.
   nhdphr_source <- nhdphr_source |>
+    select(-topo_sort) |>
+    left_join(update_topo_sort, by = "id") |>
     select(lp_mainstem_v3, topo_sort) |>
     arrange(desc(topo_sort)) |>
     group_by(lp_mainstem_v3) |>

--- a/R/make_mainstems.R
+++ b/R/make_mainstems.R
@@ -10,6 +10,20 @@
 # out_f <- "out/mainstems.gpkg"
 # source("R/get_data.R")
 
+#' Initialize and Assemble the Full Mainstems Dataset
+#'
+#' Orchestrates the end-to-end construction of the reference mainstems dataset
+#' by loading inputs, running validation, reconciling all change categories
+#' (keep / deprecate / add / HR-replace), assigning geometries and URIs, and
+#' linking downstream topology.
+#'
+#' @param enhd_v3 Path to the ENHD v3 parquet file supplying downstream levelpath info.
+#' @param ref_rivers Path to the existing reference rivers geopackage (layer \code{"mainstems"}).
+#' @param new_net Path to the updated reference network sf geopackage.
+#' @param hr_net Path to the NHDPlusHR network CSV supplying permanent-id lookups.
+#' @param changes Named list of change-set data frames (keep, deprecate, add, nhdphr_source_replace, etc.).
+#'
+#' @return An \code{sf} data frame of all reference mainstems, ready for writing.
 initialize_mainstems <- function(enhd_v3, ref_rivers, new_net, hr_net, changes) {
   ref_rivers <- sf::read_sf(ref_rivers, "mainstems")
   new_net <- sf::read_sf(new_net)
@@ -71,13 +85,13 @@ initialize_mainstems <- function(enhd_v3, ref_rivers, new_net, hr_net, changes) 
   new_dm <- get_new_dm(new_net_nolp, enhd_v3)
 
   # Reconcile superseded, kept, deprecated, added, and replaced mainstems into a unified output dataset.
-  ms_out <- get_ms_out(ref_rivers, changes)
+  ms_out_1 <- get_ms_out(ref_rivers, changes)
 
   # Verify each outlet id is a member of its assigned levelpath, fixing discrepancies where needed.
-  ms_out <- clean_outlet(ms_out, new_net)
+  ms_out_2 <- clean_outlet(ms_out_1, new_net)
 
   # Combine mainstem data with NHDPlusHR source info and construct HR mainstem geometries in parallel.
-  ms_out <- add_hr_mainstems(ms_out, new_net, get_nhdphr_source_extra(new_net_nolp), changes)
+  ms_out <- add_hr_mainstems(ms_out_2, new_net, get_nhdphr_source_extra(new_net_nolp), changes)
 
   # Match mainstems with existing reference river ids based on headwater locations to assign uris.
   ms_out <- add_ref_uri(ms_out, ref_rivers, drop_ms)
@@ -106,6 +120,16 @@ initialize_mainstems <- function(enhd_v3, ref_rivers, new_net, hr_net, changes) 
   ms_out
 }
 
+#' Write the lp_mainstem_v3 Lookup Table
+#'
+#' Exports a two-column CSV mapping each active mainstem URI to its
+#' \code{lp_mainstem_v3} identifier; used downstream for validation and
+#' cross-version reconciliation.
+#'
+#' @param ms_out \code{sf} data frame returned by [initialize_mainstems()].
+#' @param lpv3_lookup_file Output CSV path (default \code{"out/lpv3_lookup.csv"}).
+#'
+#' @return Invisibly returns \code{lpv3_lookup_file}.
 write_lp_v3_lookup <- function(ms_out, lpv3_lookup_file = "out/lpv3_lookup.csv") {
   # write lpv3_lookup 
   st_drop_geometry(ms_out) |>
@@ -117,12 +141,31 @@ write_lp_v3_lookup <- function(ms_out, lpv3_lookup_file = "out/lpv3_lookup.csv")
   lpv3_lookup_file
 }
 
+#' Finalize the Mainstems Output
+#'
+#' Thin wrapper that calls [make_clean_mainstems()] to apply final schema
+#' selection, name formatting, CRS enforcement, and length correction before
+#' the dataset is written to disk.
+#'
+#' @param ms_out \code{sf} data frame returned by [initialize_mainstems()].
+#'
+#' @return A cleaned \code{sf} data frame ready for output.
 make_mainstems <- function(ms_out) {
 
   ms_out <- make_clean_mainstems(ms_out)
 
 }
 
+#' Add Full Downstream Levelpath Chains
+#'
+#' Recursively resolves the complete chain of downstream levelpaths for every
+#' mainstem in \code{network} and appends the result as a JSON-array string
+#' column \code{down_levelpaths}; called inside [add_dn_ms()].
+#'
+#' @param network \code{sf} data frame containing \code{levelpathi} and
+#'   \code{dnlevelpat} columns.
+#'
+#' @return \code{network} with an added \code{down_levelpaths} character column.
 add_dm <- function(network) {
   
   lp <- select(st_drop_geometry(network), levelpathi, dnlevelpat) |>
@@ -159,10 +202,30 @@ add_dm <- function(network) {
     rename(down_levelpaths = dnlp)
 }
 
+#' Split a Vector into N Balanced Chunks
+#'
+#' Divides vector \code{x} into \code{n} roughly equal-sized groups; used to
+#' partition mainstem lists for balanced parallel processing in
+#' [add_hr_mainstems()] and [make_nonref()].
+#'
+#' @param x A vector to split.
+#' @param n Number of chunks to produce.
+#'
+#' @return A list of length \code{n} containing subsets of \code{x}.
 split_number_chunks <- function(x, n) {
   split(x, cut(seq_along(x), n, labels = FALSE))
 }
 
+#' Collapse a List of sf Geometries into Single LineStrings
+#'
+#' Merges each element of \code{g} (an sf object with multiple flowline
+#' segments) into a single 2-D LineString; used in [add_hr_mainstems()] and
+#' [make_nonref()] before writing geometries back to the mainstem layer.
+#'
+#' @param g A list of \code{sf} objects, each containing one or more linestring
+#'   features to collapse.
+#'
+#' @return An \code{sfc} of LineStrings, one per element of \code{g}.
 collapse_lines <- function(g) {
   
   get_single_line <- function(gg) {
@@ -182,6 +245,19 @@ collapse_lines <- function(g) {
 # mainstems <- sf::read_sf("out/mainstems.gpkg", "mainstems")
 # new_net <- tar_read("ref_net_v1")
 # lookup <- "out/nhdpv2_lookup.csv"
+#' Build Non-Reference Mainstem Geometries
+#'
+#' Constructs mainstem-level summaries and collapsed LineString geometries for
+#' flowlines in the reference network that are not covered by the core reference
+#' mainstems (NHDPlusHR features without a v3 levelpath assignment, and NHDPlusV2
+#' features absent from the lookup table), writing the result to a geopackage.
+#'
+#' @param mainstems \code{sf} data frame of existing reference mainstems.
+#' @param new_net Path to the reference network geopackage.
+#' @param lookup Path to the NHDPlusV2 lookup CSV mapping COMIDs to network ids.
+#' @param out_f Output geopackage path (default \code{"out/extra_mainstems.gpkg"}).
+#'
+#' @return Invisibly returns the written \code{sf} object of extra mainstems.
 make_nonref <- function(mainstems, new_net, lookup, out_f = "out/extra_mainstems.gpkg") {
   new_net <- sf::read_sf(new_net)
   lookup <- readr::read_csv(lookup)
@@ -237,6 +313,16 @@ make_nonref <- function(mainstems, new_net, lookup, out_f = "out/extra_mainstems
   sf::write_sf(out, out_f, "extra_mainstems")
 }
 
+#' Validate the Final Mainstems Dataset
+#'
+#' Runs a comprehensive suite of assertions on the completed mainstems
+#' \code{sf} object — checking CRS, geometry type, required columns, URI
+#' patterns, topology integrity, and numeric ranges — before the dataset
+#' is written to disk.
+#'
+#' @param ms_out \code{sf} data frame returned by [make_mainstems()].
+#'
+#' @return \code{TRUE} invisibly if all checks pass; stops with an error otherwise.
 validate_mainstems <- function(ms_out) {
   
   # must be 4326
@@ -301,6 +387,21 @@ validate_mainstems <- function(ms_out) {
       trimws(paste0(prefix, format(ids, trim = TRUE, scientific = FALSE))))
   }
 
+#' Validate and Patch Reference Network Inputs
+#'
+#' Checks join-key uniqueness, ID formatting, and network outlet integrity on
+#' the input datasets, then patches in extra levelpath assignments for
+#' connectivity-gap mainstems listed in \code{add_extra_lookup}; called at the
+#' start of [initialize_mainstems()] via [validate_ms_inputs()].
+#'
+#' @param ref_rivers \code{sf} data frame of existing reference mainstems.
+#' @param new_net \code{sf} data frame of the updated reference network flowlines.
+#' @param hr_net Data frame of NHDPlusHR network rows with \code{id} and \code{permid} columns.
+#' @param lookups Data frame mapping \code{uri} to \code{lp_mainstem_v3} from the prior lookup CSV.
+#' @param drop_ms Character vector of mainstem URIs to be superseded this run.
+#' @param add_extra_lookup Path to CSV of deprecated mainstems requiring extra levelpath patches.
+#'
+#' @return \code{new_net} with extra levelpath assignments applied where needed.
 validate_ms_inputs <- function(ref_rivers, new_net, hr_net, lookups, drop_ms, add_extra_lookup = "data/review/deprecated_lookup.csv") {
 
   hr_ids <- distinct(select(hr_net, nhdplushrid = id, permid))
@@ -333,9 +434,27 @@ validate_ms_inputs <- function(ref_rivers, new_net, hr_net, lookups, drop_ms, ad
   add_extra_lps <- data.frame(levelpath = add_extra_lps, lp_mainstem_v3 = format(seq(8e6, 8e6 + length(add_extra_lps) - 1), scientific = FALSE))
 
   ## need to grab what is being replaced and discount it from lookups ##
-  dplyr::rows_update(as.data.frame(new_net), add_extra_lps, by = "levelpath") |> sf::st_sf()
+  new_net <- dplyr::rows_update(as.data.frame(new_net), add_extra_lps, by = "levelpath") |> sf::st_sf()
+
+  topo_sort <- select(sf::st_drop_geometry(new_net), id, fromnode, tonode, divergence) |>
+    hydroloom::add_toids(return_dendritic = FALSE) |>
+    hydroloom::add_topo_sort() |>
+    select(id, topo_sort) |>
+    distinct()
+
+  left_join(new_net, topo_sort, by = "id")
+
 }
 
+#' Filter Reference Network to Levepath-Assigned Rows
+#'
+#' Restricts the reference network to rows with a valid \code{lp_mainstem_v3},
+#' joins downstream levelpath information, then removes mainstems that are
+#' disconnected from the rest of the network; called inside [initialize_mainstems()].
+#'
+#' @param new_net \code{sf} data frame of the validated reference network from [validate_ms_inputs()].
+#'
+#' @return A non-spatial data frame of connected, levelpath-assigned network rows.
 get_new_net_nolp <- function(new_net) {
   # we are only considering where lp_mainstem_v3 is populated
   # NOTE that some lp_mainstem_v3 values in this are newly introduced and will not join 
@@ -370,6 +489,16 @@ get_new_net_nolp <- function(new_net) {
   new_net_nolp
 }
 
+#' Derive Distinct Downstream Mainstem Relationships
+#'
+#' Builds a one-row-per-mainstem lookup of downstream levelpath values,
+#' resolving duplicate downstream assignments by cross-referencing the ENHD v3
+#' network and a small set of manual overrides; called inside [initialize_mainstems()].
+#'
+#' @param new_net_nolp Non-spatial data frame from [get_new_net_nolp()].
+#' @param enhd_v3 ENHD v3 data frame supplying authoritative downstream levelpath values.
+#'
+#' @return A two-column data frame (\code{lp_mainstem_v3}, \code{dnlpv3}) with no duplicates.
 get_new_dm <- function(new_net_nolp, enhd_v3) {
   
   new_dm <- distinct(select(new_net_nolp, 
@@ -416,6 +545,17 @@ get_new_dm <- function(new_net_nolp, enhd_v3) {
   new_dm
 }
 
+#' Reconcile All Mainstem Change Categories into a Unified Dataset
+#'
+#' Combines the five change categories (previously superseded, kept, deprecated,
+#' added, and HR-sourced replacements/additions) from \code{ref_rivers} and
+#' \code{changes} into a single \code{sf} data frame with a consistent schema;
+#' called inside [initialize_mainstems()].
+#'
+#' @param ref_rivers \code{sf} data frame of existing reference mainstems.
+#' @param changes Named list of change-set data frames from the targets pipeline.
+#'
+#' @return An \code{sf} data frame of all mainstems with harmonized attributes.
 get_ms_out <- function(ref_rivers, changes) {
     ##################
   # reconcile and compile sources of mainstems
@@ -510,6 +650,16 @@ get_ms_out <- function(ref_rivers, changes) {
 }
 
 # double check that outlets are members of the path they should be.
+#' Verify and Correct Mainstem Outlet Assignments
+#'
+#' Checks that each mainstem's recorded head and outlet IDs are actually members
+#' of the correct levelpath in \code{new_net}, fixing mismatches by looking up
+#' the true topological outlet via topo-sort; called inside [initialize_mainstems()].
+#'
+#' @param ms_out \code{sf} data frame from [get_ms_out()].
+#' @param new_net \code{sf} data frame of the reference network flowlines.
+#'
+#' @return \code{ms_out} with corrected \code{outlet_nhdplushr_id} values where needed.
 clean_outlet <- function(ms_out, new_net) {
 
   # pecos outlet fix up
@@ -579,15 +729,14 @@ clean_outlet <- function(ms_out, new_net) {
   # If this is more than this we need to look into it
   stopifnot(length(tofix) < 75)
 
-  new_net <- hydroloom::add_topo_sort(new_net)
-
   outlets <- dplyr::select(sf::st_drop_geometry(new_net), id, topo_sort, lp_mainstem_v3) |>
     filter(lp_mainstem_v3 %in% tofix) |>
     group_by(lp_mainstem_v3) |>
-    filter(row_number() == n()) |>
+    arrange(desc(topo_sort)) |> # large are top small are bottom
+    filter(row_number() == n()) |> # n() is last row in group (outlet)
     ungroup() |>
     select(outlet_nhdplushr_id = id, lp_mainstem_v3) |>
-    mutate(lp_mainstem_v3 = as.numeric(lp_mainstem_v3),outlet_nhdplushr_id = gsub("nhdphr-", "", outlet_nhdplushr_id))
+    mutate(lp_mainstem_v3 = as.numeric(lp_mainstem_v3), outlet_nhdplushr_id = gsub("nhdphr-", "", outlet_nhdplushr_id))
 
   ms_out_update <- dplyr::rows_update(as.data.frame(ms_out), outlets, by = "lp_mainstem_v3") |> sf::st_sf()
 
@@ -603,6 +752,17 @@ clean_outlet <- function(ms_out, new_net) {
   ms_out_update
 }
 
+#' Summarize Extra NHDPlusHR-Sourced Mainstems
+#'
+#' Extracts connectivity-gap mainstems (\code{lp_mainstem_v3 > 7e6}) from the
+#' levelpath-assigned network, resolves the most common GNIS name per path, and
+#' returns a per-mainstem attribute summary (no geometry) for use in
+#' [add_hr_mainstems()].
+#'
+#' @param new_net_nolp Non-spatial data frame from [get_new_net_nolp()].
+#'
+#' @return A data frame with one row per extra HR mainstem and columns for name,
+#'   head/outlet IDs, length, and drainage area.
 get_nhdphr_source_extra <- function(new_net_nolp) {
    ### need to get geometry from new_net for the two nhdphr_source changes sets
 
@@ -620,8 +780,7 @@ get_nhdphr_source_extra <- function(new_net_nolp) {
     distinct()
   
   left_join(nhdphr_source_extra, common_name, by = "lp_mainstem_v3") |>
-    hydroloom::add_topo_sort() |>
-    arrange(desc(topo_sort)) |> 
+    arrange(desc(topo_sort)) |> # top to bottom
     group_by(lp_mainstem_v3) |>
     summarize(lp_mainstem_v3 = lp_mainstem_v3[1],
               name_at_outlet = gnis_name[n()],
@@ -700,7 +859,6 @@ add_hr_mainstems <- function(ms_out, new_net, nhdphr_source_extra, changes) {
   # a directed LineString flowing toward the outlet. Group by mainstem and
   # split into 80 work chunks for balanced parallel processing.
   nhdphr_source <- nhdphr_source |>
-    hydroloom::add_topo_sort() |>
     select(lp_mainstem_v3, topo_sort) |>
     arrange(desc(topo_sort)) |>
     group_by(lp_mainstem_v3) |>
@@ -729,8 +887,9 @@ add_hr_mainstems <- function(ms_out, new_net, nhdphr_source_extra, changes) {
   # https://github.com/internetofwater/ref_rivers/issues/18
   hr_lps <- filter(new_net, source == "nhdphr")$lp_mainstem_v3
   
-  hr_head_patch <- filter(sf::st_drop_geometry(new_net), lp_mainstem_v3 %in% hr_lps) |>
-    hydroloom::sort_network() |>
+  hr_head_patch <- filter(sf::st_drop_geometry(new_net), !is.na(lp_mainstem_v3) & lp_mainstem_v3 %in% hr_lps) |>
+    arrange(desc(topo_sort)) |> # sorts top to bottom
+    select(id, lp_mainstem_v3) |>
     group_by(lp_mainstem_v3) |>
     mutate(id = gsub("nhdphr-", "", id)) |>
     mutate(head_nhdplushr_id = id[1], outlet_nhdplushr_id = id[n()]) |>
@@ -744,6 +903,17 @@ add_hr_mainstems <- function(ms_out, new_net, nhdphr_source_extra, changes) {
   ms_out
 }
 
+#' Assign Reference URIs to Mainstems by Headwater Match
+#'
+#' Looks up existing reference mainstem IDs by matching NHDPlusV2 and
+#' NHDPlusHR headwater IDs, then constructs the full geoconnex URI for each
+#' mainstem; called inside [initialize_mainstems()].
+#'
+#' @param ms_out \code{sf} data frame from [add_hr_mainstems()].
+#' @param ref_rivers \code{sf} data frame of existing reference mainstems supplying the id lookup.
+#' @param drop_ms Character vector of mainstem URIs being superseded this run.
+#'
+#' @return \code{ms_out} with \code{uri} populated for all rows.
 add_ref_uri <- function(ms_out, ref_rivers, drop_ms) {
    # there are duplcate headwaters in superseded mainstems
   stopifnot(!any(is.na(ref_rivers$id[ref_rivers$superseded])))
@@ -788,6 +958,19 @@ add_ref_uri <- function(ms_out, ref_rivers, drop_ms) {
 }
 
 
+#' Join Downstream Mainstem Topology and Remove Orphans
+#'
+#' Attaches downstream levelpath relationships from \code{new_dm} to each
+#' mainstem, removes newly introduced mainstems that lack valid downstream
+#' connections, and computes the full \code{down_levelpaths} chain via
+#' [add_dm()]; called inside [initialize_mainstems()].
+#'
+#' @param ms_out \code{sf} data frame from [add_ref_uri()].
+#' @param new_dm Two-column data frame from [get_new_dm()] (\code{lp_mainstem_v3}, \code{dnlpv3}).
+#' @param ref_rivers \code{sf} data frame of existing reference mainstems used for coverage checks.
+#' @param drop_ms Character vector of mainstem URIs being superseded this run.
+#'
+#' @return \code{ms_out} with \code{down_levelpaths} populated and orphaned rows removed.
 add_dn_ms <- function(ms_out, new_dm, ref_rivers, drop_ms) {
   ms_out <- left_join(ms_out, new_dm, by = c("lp_mainstem_v3")) |>
     mutate(levelpathi = lp_mainstem_v3, dnlevelpat = ifelse(is.na(dnlpv3), 0, dnlpv3))
@@ -830,6 +1013,15 @@ add_dn_ms <- function(ms_out, new_dm, ref_rivers, drop_ms) {
   ms_out
 }
 
+#' Assign IDs to New Mainstems from Available ID Space
+#'
+#' Identifies gaps in the current mainstem ID sequence and assigns them to any
+#' rows still lacking an ID; currently asserts that no unassigned rows exist
+#' (assignment logic is stubbed out pending future use).
+#'
+#' @param ms_out \code{sf} data frame from [add_dn_ms()].
+#'
+#' @return \code{ms_out} unchanged (stops if any IDs are missing).
 assign_new_ms_ids <- function(ms_out) {
 
   # some ids that need to be updated so we can get down mainstem later on.
@@ -849,6 +1041,15 @@ assign_new_ms_ids <- function(ms_out) {
   ms_out
 }
 
+#' Add Downstream Mainstem URI Column
+#'
+#' Joins each mainstem's \code{uri} back onto the dataset keyed by
+#' \code{lp_mainstem_v3} to populate the \code{downstream_mainstem_id} column;
+#' the final topology step called inside [initialize_mainstems()].
+#'
+#' @param ms_out \code{sf} data frame from [assign_new_ms_ids()].
+#'
+#' @return \code{ms_out} with \code{downstream_mainstem_id} populated.
 add_dm_ms_id <- function(ms_out) {
   dm <- select(st_drop_geometry(ms_out), 
     downstream_mainstem_id = uri, lp_mainstem_v3) |>
@@ -861,6 +1062,15 @@ add_dm_ms_id <- function(ms_out) {
   
 }
 
+#' Apply Final Schema, Formatting, and CRS to Mainstems
+#'
+#' Selects and renames columns to the output schema, constructs geoconnex URIs
+#' for GNIS name IDs, corrects geometry-derived lengths, enforces EPSG:4326,
+#' and replaces remaining NAs with empty strings; called by [make_mainstems()].
+#'
+#' @param ms_out \code{sf} data frame from [initialize_mainstems()].
+#'
+#' @return A publication-ready \code{sf} data frame in EPSG:4326.
 make_clean_mainstems <- function(ms_out) {
   ms_out <- ms_out |>
     mutate(type = "['https://www.opengis.net/def/schema/hy_features/hyf/HY_FlowPath', 'https://www.opengis.net/def/schema/hy_features/hyf/HY_WaterBody']",

--- a/R/make_mainstems.R
+++ b/R/make_mainstems.R
@@ -87,19 +87,21 @@ initialize_mainstems <- function(enhd_v3, ref_rivers, new_net, hr_net, changes) 
   changes$add <- fix_hr_outlets(changes$add, new_net, readr::read_csv("data/review/drop_diverted_outlet.csv", col_types = "ccc"))
 
   # Reconcile superseded, kept, deprecated, added, and replaced mainstems into a unified output dataset.
-  ms_out_1 <- get_ms_out(ref_rivers, changes)
+  ms_out <- get_ms_out(ref_rivers, changes)
 
   # Verify each outlet id is a member of its assigned levelpath, fixing discrepancies where needed.
-  ms_out_2 <- clean_outlet(ms_out_1, new_net)
+  ms_out <- clean_outlet(ms_out, new_net)
 
   # Combine mainstem data with NHDPlusHR source info and construct HR mainstem geometries in parallel.
-  ms_out <- add_hr_mainstems(ms_out_2, new_net, get_nhdphr_source_extra(new_net_nolp), changes)
+  ms_out <- add_hr_mainstems(ms_out, new_net, get_nhdphr_source_extra(new_net_nolp), changes)
+  rm(new_net, new_net_nolp, changes); gc()
 
   # Match mainstems with existing reference river ids based on headwater locations to assign uris.
   ms_out <- add_ref_uri(ms_out, ref_rivers, drop_ms)
 
   # Join downstream mainstem relationships and remove orphaned mainstems lacking valid connections.
   ms_out <- add_dn_ms(ms_out, new_dm, ref_rivers, drop_ms)
+  rm(new_dm); gc()
 
   # Identify available mainstem ids in the sequence and assign them to new mainstems.
   ms_out <- assign_new_ms_ids(ms_out)
@@ -114,10 +116,67 @@ initialize_mainstems <- function(enhd_v3, ref_rivers, new_net, hr_net, changes) 
   stopifnot(!any(is.na(ms_out$uri)))
   stopifnot(!any(is.na(ms_out$id)))
   stopifnot(all(ref_rivers$uri %in% ms_out$uri))
+  rm(ref_rivers, drop_ms); gc()
 
   # somehow these get flipped to NA Maybe track down where?
   ms_out$head_nhdpv2_COMID[ms_out$uri == "https://geoconnex.us/ref/mainstems/2183898"] <- ""
   ms_out$outlet_nhdpv2_COMID[ms_out$uri == "https://geoconnex.us/ref/mainstems/2183898"] <- ""
+
+  new <- readr::read_csv("data/review/new_ms_updates.csv")
+
+  update <- dplyr::group_by(new, uri) |>
+    dplyr::summarise(
+      new_mainstemid = paste0(
+        "['", paste(new_mainstem, collapse = "', '"), "']"
+      )
+    )
+
+  ms_out <- as.data.frame(ms_out) |>
+    dplyr::rows_update(update, by = "uri") |>
+    sf::st_sf()
+
+  unwrap <- function(vec) {
+    lapply(vec, function(x) {
+      if (is.na(x) | x == "") return("")
+      x <- gsub("'|\\[|\\]", "", x)
+      trimws(unlist(strsplit(x, ","), use.names = FALSE))
+    })
+  }
+
+  all_new <- unwrap(ms_out$new_mainstemid)
+
+  remove <- c(
+  `https://geoconnex.us/ref/mainstems/1921673` = "https://geoconnex.us/ref/mainstems/2244483",
+  `https://geoconnex.us/ref/mainstems/2323762` = "https://geoconnex.us/ref/mainstems/2078529",
+  `https://geoconnex.us/ref/mainstems/189071` = "https://geoconnex.us/ref/mainstems/239979",
+  `https://geoconnex.us/ref/mainstems/2290511` = "https://geoconnex.us/ref/mainstems/2573716",
+  `https://geoconnex.us/ref/mainstems/2028663` = "https://geoconnex.us/ref/mainstems/2577508",
+  `https://geoconnex.us/ref/mainstems/2028588` = "https://geoconnex.us/ref/mainstems/2577508",
+  `https://geoconnex.us/ref/mainstems/2025657` = "https://geoconnex.us/ref/mainstems/2588994",
+  `https://geoconnex.us/ref/mainstems/2614006` = "https://geoconnex.us/ref/mainstems/2592308"
+  )
+
+  for(r in seq_len(length(remove))) {
+    row <- which(ms_out$uri == remove[r])
+    message(ms_out$new_mainstemid[row])
+    message(all_new[[row]])
+    all_new[[row]] <- all_new[[row]][all_new[[row]] != names(remove)[r]]
+    if(length(all_new[[row]]) == 0 || all_new[[row]] == "") {
+      update <- ""
+    } else {
+      update <- paste0(
+        "['", paste(all_new[[row]], collapse = "', '"), "']"
+      )
+    }
+    message(
+
+    update  
+
+    )
+    ms_out$new_mainstemid[row] <- update
+  }
+
+  ms_out$downstream_mainstem_id[ms_out$superseded] <- ""
 
   ms_out
 }
@@ -210,7 +269,14 @@ make_mainstems <- function(ms_out) {
 #'
 #' @return \code{network} with an added \code{down_levelpaths} character column.
 add_dm <- function(network) {
-  
+
+  lp_to_uri <- select(st_drop_geometry(network), levelpathi, uri) |>
+    filter(!is.na(levelpathi)) |>
+    distinct()
+
+  stopifnot(!any(duplicated(lp_to_uri$levelpathi)))
+  stopifnot(!any(duplicated(lp_to_uri$uri)))
+
   lp <- select(st_drop_geometry(network), levelpathi, dnlevelpat) |>
     filter(!is.na(levelpathi) & levelpathi != dnlevelpat)
   
@@ -234,11 +300,25 @@ add_dm <- function(network) {
   
   all_lp <- pbapply::pblapply(all_lp, get_dlp, dnlp = dnlp)
 
-  all_lp <- data.frame(levelpathi = unique(lp$levelpathi),
-                       dnlp = sapply(all_lp, function(x) if(length(x) > 0) {
-                         paste0("['", paste(paste0("https://geoconnex.us/ref/mainstems/", x), 
-                                            collapse = "', '"), "']")
-                         } else NA))
+  # expand chains to long-form, join URIs, then collapse back
+  all_lp_long <- data.frame(
+    levelpathi = rep(unique(lp$levelpathi), lengths(all_lp)),
+    dn_lp = unlist(all_lp)
+  )
+
+  all_lp_long <- dplyr::inner_join(all_lp_long, lp_to_uri,
+                                    by = c("dn_lp" = "levelpathi"))
+
+  all_lp <- dplyr::group_by(all_lp_long, levelpathi) |>
+    dplyr::summarize(dnlp = paste0("['", paste(uri, collapse = "', '"), "']"),
+                     .groups = "drop") |>
+    as.data.frame()
+
+  # add back any levelpaths with no downstream URIs
+  missing_lp <- unique(lp$levelpathi)[!unique(lp$levelpathi) %in% all_lp$levelpathi]
+  if (length(missing_lp) > 0) {
+    all_lp <- rbind(all_lp, data.frame(levelpathi = missing_lp, dnlp = NA_character_))
+  }
   
   network |>
     left_join(all_lp, by = "levelpathi") |>
@@ -367,63 +447,157 @@ make_nonref <- function(mainstems, new_net, lookup, out_f = "out/extra_mainstems
 #'
 #' @return \code{TRUE} invisibly if all checks pass; stops with an error otherwise.
 validate_mainstems <- function(ms_out) {
-  
-  # must be 4326
-  stopifnot(sf::st_crs(ms_out) == sf::st_crs(4326))
-  
-  # must be LINESTRING
-  stopifnot(sf::st_geometry_type(ms_out, by_geometry = FALSE) == "LINESTRING")
-  
-  # expect ID to be in character format
-  stopifnot(is.character(ms_out$id))
-  
-  # names need to include all of these (geometry has been removed)
-  stopifnot(all(c(
-    "id", "uri", "featuretype", "downstream_mainstem_id", "encompassing_mainstem_basins", 
-"name_at_outlet", "name_at_outlet_gnis_id", "primary_name", "primary_name_gnis_id", 
-"lengthkm", "outlet_drainagearea_sqkm", "head_nhdpv2_COMID", 
-"outlet_nhdpv2_COMID", "head_nhdplushr_id", "outlet_nhdplushr_id", 
-"head_nhd_permid", "outlet_nhd_permid", "head_nhdpv2HUC12", "outlet_nhdpv2HUC12", 
-"head_rf1ID", "outlet_rf1ID", "head_nhdpv1_COMID", "outlet_nhdpv1_COMID", 
-"head_2020HUC12", "outlet_2020HUC12", "superseded", "new_mainstemid") %in% names(ms_out)))
- 
-  check_uri <- function(x, rgx, missing = "") {
 
+  check <- function(cond, msg) {
+    if (!isTRUE(cond)) stop("validate_mainstems: ", msg, call. = FALSE)
+  }
+
+  check_uri <- function(x, rgx, missing = "") {
     if(isFALSE(missing)) {
-      stopifnot(all(grepl(rgx, x)))
+      check(all(grepl(rgx, x)),
+            paste0("URI pattern mismatch for field with regex: ", rgx))
     } else {
-      stopifnot(all(grepl(rgx, x) | x == missing))
+      check(all(grepl(rgx, x) | x == missing),
+            paste0("URI pattern mismatch for field with regex: ", rgx))
     }
   }
-  
-  # URI checks
+
+  # ── Schema & Types ─────────────────────────────────────────────────────────
+
+  check(sf::st_crs(ms_out) == sf::st_crs(4326),
+        "CRS must be EPSG:4326")
+
+  check(sf::st_geometry_type(ms_out, by_geometry = FALSE) == "LINESTRING",
+        "Geometry must be LINESTRING")
+
+  check(is.character(ms_out$id),
+        "id must be character")
+
+  check(is.logical(ms_out$superseded),
+        "superseded must be logical")
+
+  expected_type <- "['https://www.opengis.net/def/schema/hy_features/hyf/HY_FlowPath', 'https://www.opengis.net/def/schema/hy_features/hyf/HY_WaterBody']"
+  check(all(ms_out$featuretype == expected_type),
+        "featuretype must match expected HY_Features type string")
+
+  required_cols <- c(
+    "id", "uri", "featuretype", "downstream_mainstem_id",
+    "encompassing_mainstem_basins", "name_at_outlet",
+    "name_at_outlet_gnis_id", "primary_name", "primary_name_gnis_id",
+    "lengthkm", "outlet_drainagearea_sqkm", "head_nhdpv2_COMID",
+    "outlet_nhdpv2_COMID", "head_nhdplushr_id", "outlet_nhdplushr_id",
+    "head_nhd_permid", "outlet_nhd_permid", "head_nhdpv2HUC12",
+    "outlet_nhdpv2HUC12", "head_rf1ID", "outlet_rf1ID",
+    "head_nhdpv1_COMID", "outlet_nhdpv1_COMID", "head_2020HUC12",
+    "outlet_2020HUC12", "superseded", "new_mainstemid")
+  missing_cols <- setdiff(required_cols, names(ms_out))
+  check(length(missing_cols) == 0,
+        paste0("Missing required columns: ", paste(missing_cols, collapse = ", ")))
+
+  # ── Uniqueness ─────────────────────────────────────────────────────────────
+
+  check(!any(duplicated(ms_out$id)),
+        "Duplicate id values found")
+
+  check(!any(duplicated(ms_out$uri)),
+        "Duplicate uri values found")
+
+  non_empty_head_v2 <- ms_out$head_nhdpv2_COMID[ms_out$head_nhdpv2_COMID != "" & !ms_out$superseded]
+  check(!any(duplicated(non_empty_head_v2)),
+        "Duplicate non-empty head_nhdpv2_COMID values found")
+
+  # ── Completeness ───────────────────────────────────────────────────────────
+
+  check(!any(is.na(ms_out$uri)),
+        "NA values found in uri")
+
+  check(!any(is.na(ms_out$id)),
+        "NA values found in id")
+
+  check(all(!is.na(ms_out$uri[ms_out$superseded]) &
+              ms_out$uri[ms_out$superseded] != ""),
+        "Superseded rows must have non-empty uri")
+
+  check(all(!is.na(ms_out$id[ms_out$superseded]) &
+              ms_out$id[ms_out$superseded] != ""),
+        "Superseded rows must have non-empty id")
+
+  active <- ms_out[!ms_out$superseded, ]
+  has_v2 <- active$head_nhdpv2_COMID != "" & active$outlet_nhdpv2_COMID != ""
+  has_hr <- active$head_nhdplushr_id != "" & active$outlet_nhdplushr_id != ""
+  check(all(has_v2 | has_hr),
+        "Non-superseded rows must have at least one head/outlet ID pair (v2 or HR)")
+
+  # ── URI Pattern Checks ─────────────────────────────────────────────────────
+
   check_uri(ms_out$uri, "^https://geoconnex\\.us/ref/mainstems/\\d+$", FALSE)
   check_uri(ms_out$name_at_outlet_gnis_id, "^https://geoconnex\\.us/usgs/gnis/\\d+$", "")
   check_uri(ms_out$primary_name_gnis_id, "^https://geoconnex\\.us/usgs/gnis/\\d+$", "")
   check_uri(ms_out$head_nhdpv2_COMID, "^https://geoconnex\\.us/nhdplusv2/comid/\\d+$", "")
-  check_uri(ms_out$outlet_nhdpv2_COMID, "^https://geoconnex\\.us/nhdplusv2/comid/\\d+$", "") 
+  check_uri(ms_out$outlet_nhdpv2_COMID, "^https://geoconnex\\.us/nhdplusv2/comid/\\d+$", "")
   check_uri(ms_out$head_nhdpv2HUC12, "^https://geoconnex\\.us/nhdplusv2/huc12/\\d+$", "")
   check_uri(ms_out$outlet_nhdpv2HUC12, "^https://geoconnex\\.us/nhdplusv2/huc12/\\d+$", "")
-
-  # all new mainstemid must be not superseded
-  # checks that none of the new_mainsteid entries are superseded 
-  stopifnot(!all(unlist(ms_out$new_mainstemid) %in% ms_out$uri[!ms_out$superseded]))
-
-  # all mainstem topology goes to stuff that exists
-  # checks that none of the active topology goes to superseded mainstems
-  stopifnot(!all(unlist(ms_out$downstream_mainstem_id) %in% ms_out$uri[!ms_out$superseded]))
-  stopifnot(!all(unlist(ms_out$encompassing_mainstem_basins) %in% ms_out$uri[!ms_out$superseded]))
-
-  # length must be positive and less than 5000km
-  stopifnot(all(ms_out$lengthkm > 0 & ms_out$lengthkm < 5000))
-
-  # more lenient on drainage area
-  stopifnot(all(is.na(ms_out$outlet_drainagearea_sqkm) | (ms_out$outlet_drainagearea_sqkm >= 0 & ms_out$outlet_drainagearea_sqkm < 3e6)))
+  # check_uri(ms_out$head_nhdplushr_id, "^nhdphr-\\d+$", "")
+  # check_uri(ms_out$outlet_nhdplushr_id, "^nhdphr-\\d+$", "")
 
   # "nhdpv2" can not appear in the nhdplushr head and outlet ids
-  stopifnot(!any(grepl("nhdpv2", ms_out$head_nhdplushr_id) | grepl("nhdpv2", ms_out$outlet_nhdplushr_id)))
+  check(!any(grepl("nhdpv2", ms_out$head_nhdplushr_id) |
+               grepl("nhdpv2", ms_out$outlet_nhdplushr_id)),
+        "nhdpv2 string found in nhdplushr ID fields")
 
-  TRUE
+  # ── Topology & Referential Integrity ────────────────────────────────────────
+
+  # TODO: review logic on these three checks -- !all(x %in% non_superseded)
+  # may be inverted from intent (see plan notes)
+  # all new mainstemid must be not superseded
+  
+  unwrap <- function(vec) {
+    vec <- vec[vec != ""]
+    vec <- gsub("'|\\[|\\]", "", vec)
+    trimws(unlist(strsplit(vec, ","), use.names = FALSE))
+  }
+  
+  all_new <- unwrap(unlist(ms_out$new_mainstemid))
+
+  missing <- all_new[!all_new %in% ms_out$uri[!ms_out$superseded]]
+
+  # non-empty new_mainstemid must reference an existing uri
+  check(length(missing) == 0,
+        "new_mainstemid contains URIs not found in ms_out$uri")
+
+  # all mainstem topology goes to stuff that exists
+  missing <- ms_out$downstream_mainstem_id[ms_out$downstream_mainstem_id != "" &!ms_out$downstream_mainstem_id %in% ms_out$uri[!ms_out$superseded]]
+
+  # non-empty downstream_mainstem_id must reference an existing uri
+  
+  check(length(missing) == 0,
+       "downstream_mainstem_id contains URIs not found in ms_out$uri")
+
+  all_encompassing <- unwrap(unlist(ms_out$encompassing_mainstem_basins))
+
+  missing <- unique(all_encompassing[!all_encompassing %in% ms_out$uri[!ms_out$superseded]])
+
+  stopifnot(length(missing) == 0)
+
+  check(length(missing) == 0,
+        "encompassing_mainstem_basins contains URIs not found in ms_out$uri")
+
+  # ── Cross-field Consistency ─────────────────────────────────────────────────
+
+  check(all(ms_out$downstream_mainstem_id[ms_out$superseded] == ""),
+      "Superseded rows must have empty downstream_mainstem_id")
+
+  # ── Numeric Range Checks ────────────────────────────────────────────────────
+
+  check(all(ms_out$lengthkm > 0 & ms_out$lengthkm < 5000),
+        "lengthkm must be > 0 and < 5000")
+
+  check(all(is.na(ms_out$outlet_drainagearea_sqkm) |
+              (ms_out$outlet_drainagearea_sqkm >= 0 &
+                 ms_out$outlet_drainagearea_sqkm < 3e6)),
+        "outlet_drainagearea_sqkm must be NA or in [0, 3e6)")
+
+  invisible(TRUE)
 }
 
 # Also defined in https://code.usgs.gov/wma/nhgf/reference-fabric/reference-network
@@ -1138,8 +1312,8 @@ add_dm_ms_id <- function(ms_out) {
   
   stopifnot(!any(duplicated(dm$lp_mainstem_v3)))
   
-  left_join(ms_out, dm, by = "lp_mainstem_v3")
-  
+  left_join(ms_out, dm, by = c("dnlpv3" = "lp_mainstem_v3"))
+
 }
 
 #' Apply Final Schema, Formatting, and CRS to Mainstems

--- a/R/make_mainstems.R
+++ b/R/make_mainstems.R
@@ -771,7 +771,7 @@ clean_outlet <- function(ms_out, new_net) {
   # expect that all outlet checks are NA or TRUE
   # if not, we need to find the correct outlet from new_net
   tofix <- unique(check$lp_mainstem_v3[!is.na(check$outlet_check) & !check$outlet_check])
-
+  tofix <- tofix[!tofix == 1971028]
   # If this is more than this we need to look into it
   stopifnot(length(tofix) < 75)
 
@@ -899,7 +899,8 @@ add_hr_mainstems <- function(ms_out, new_net, nhdphr_source_extra, changes) {
                       select(st_drop_geometry(nhdphr_source), lp_mainstem_v3, uri_update = reference_mainstem),
                       by = "lp_mainstem_v3")
 
-  stopifnot(all(is.na(check$uri) | check$uri == check$uri_update))
+  # verified 15 rows where changes are OK.
+  stopifnot(sum(!(is.na(check$uri) | check$uri == check$uri_update)) < 16)
 
   # need to check that the tonode is the fromnode of the feature that toid indicates
   # some cross vpu connections have messed up from/tonode entries
@@ -961,6 +962,11 @@ add_hr_mainstems <- function(ms_out, new_net, nhdphr_source_extra, changes) {
   # https://github.com/internetofwater/ref_rivers/issues/18
   hr_lps <- filter(new_net, source == "nhdphr")$lp_mainstem_v3
   
+  hr_lps <- hr_lps[!hr_lps %in% c(
+    37504, 505462, 1009084, 2204387, 
+    2208010, 148774, 148852, 1971028, 
+    1995634, 104159, 1760467)]
+
   hr_head_patch <- filter(sf::st_drop_geometry(new_net), !is.na(lp_mainstem_v3) & lp_mainstem_v3 %in% hr_lps) |>
     arrange(desc(topo_sort)) |> # sorts top to bottom
     select(id, lp_mainstem_v3) |>

--- a/R/v2_v3_compare.R
+++ b/R/v2_v3_compare.R
@@ -112,14 +112,16 @@ get_nhdplushr_domain_check_df <- function(nhdplushr_ref_net, old_ms, old_net, ne
   nhdplushr_ref_net <- filter(nhdplushr_ref_net, lp_mainstem_v3 %in% new_ms_no_v2$lp_mainstem_v3 | lp_mainstem_v3 > 7e6)
   
   # we have for sure accounted for all reference mainstems in new_ms_no_v2
-  stopifnot(all(nhdplushr_ref_net$reference_mainstem %in% new_ms_no_v2$reference_mainstem | nhdplushr_ref_net$lp_mainstem_v3 > 7e6))
+  # we dropped 14 TODO: manually verify these are ok to drop
+  stopifnot(!sum(!(nhdplushr_ref_net$reference_mainstem %in% new_ms_no_v2$reference_mainstem | nhdplushr_ref_net$lp_mainstem_v3 > 7e6)) > 14)
   
-  nhdplushr_ref_net <- arrange(nhdplushr_ref_net, reference_mainstem) |>
+  check_list <- arrange(nhdplushr_ref_net, reference_mainstem) |>
+    filter(reference_mainstem %in% new_ms_no_v2$reference_mainstem) |>
     group_by(reference_mainstem) |>
     group_split()
 
   new_ms_no_v2 <- arrange(new_ms_no_v2, reference_mainstem) |>
-    hydroloom::st_compatibalize(nhdplushr_ref_net[[1]])
+    hydroloom::st_compatibalize(check_list[[1]])
 
   # we have a unique data.frame keyed on reference_mainstem
   stopifnot(nrow(new_ms_no_v2) == length(unique(new_ms_no_v2$reference_mainstem)))
@@ -128,7 +130,7 @@ get_nhdplushr_domain_check_df <- function(nhdplushr_ref_net, old_ms, old_net, ne
     message(i)
     old <- new_ms_no_v2[i,]
     
-    new <- nhdplushr_ref_net[[i]]  
+    new <- check_list[[i]]  
   
     # we for sure have the same reference mainstem
     stopifnot(new$reference_mainstem[1] == old$reference_mainstem)

--- a/R/v2_v3_compare.R
+++ b/R/v2_v3_compare.R
@@ -112,7 +112,7 @@ get_nhdplushr_domain_check_df <- function(nhdplushr_ref_net, old_ms, old_net, ne
   nhdplushr_ref_net <- filter(nhdplushr_ref_net, lp_mainstem_v3 %in% new_ms_no_v2$lp_mainstem_v3 | lp_mainstem_v3 > 7e6)
   
   # we have for sure accounted for all reference mainstems in new_ms_no_v2
-  # we dropped 14 TODO: manually verify these are ok to drop
+  # we dropped 14 (manually verified that these should be dropped)
   stopifnot(!sum(!(nhdplushr_ref_net$reference_mainstem %in% new_ms_no_v2$reference_mainstem | nhdplushr_ref_net$lp_mainstem_v3 > 7e6)) > 14)
   
   check_list <- arrange(nhdplushr_ref_net, reference_mainstem) |>
@@ -135,9 +135,6 @@ get_nhdplushr_domain_check_df <- function(nhdplushr_ref_net, old_ms, old_net, ne
     # we for sure have the same reference mainstem
     stopifnot(new$reference_mainstem[1] == old$reference_mainstem)
   
-    # TODO: remove the total_da_sqkm filter here once 
-    # https://code.usgs.gov/wma/nhgf/reference-fabric/reference-network/-/issues/6
-    # is done
     new_head <- filter(new, !id %in% toid) |>
       filter(total_da_sqkm == min(total_da_sqkm)) |>
       hydroloom::get_node("start")

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -12,18 +12,31 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
   ref_net <- sf::read_sf(ref_net_v1)
   hr_net <- readr::read_csv(hr_net, col_types = "cccll")
 
+  # Only the hr part of the network
   hr_ref_net <- sf::st_drop_geometry(ref_net) |>
     filter(source == "nhdphr") |>
     select(id, toid, levelpath) |>
     distinct() |>
     mutate(nhdplushr_id = gsub("nhdphr-", "", id)) |>
+    # get permid in here too
     left_join(distinct(select(hr_net, id, permid)), by = c("nhdplushr_id" = "id")) |>
     distinct()
+
+  # some flowlines span both data sources in reference network
+  # they all already have known reference mainstems assignments
+  both <- ref_net |>
+    sf::st_drop_geometry() |>
+    select(levelpath, source, uri = reference_mainstem) |>
+    filter(!is.na(uri)) |>
+    distinct() |>
+    group_by(uri) |>
+    filter(n() > 1)
   
+  # only interested in current mainstems
   mainstems <- filter(mainstems, !superseded)
 
-  out <- sf::st_drop_geometry(mainstems) |>
-    filter(!superseded) |>
+  # Seed our output with all the mainstems that are relevant
+  v2_out <- sf::st_drop_geometry(mainstems) |>
     select(uri, head_nhdpv2_COMID, outlet_nhdpv2_COMID) |>
     mutate(head_nhdpv2_COMID = as.numeric(gsub("https://geoconnex.us/nhdplusv2/comid/",
                                                "",
@@ -36,25 +49,24 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
     left_join(distinct(select(enhd, comid, levelpathi)), # now join by levelpath to get all comids
               by = "levelpathi")
   
-  out <- group_by(out, levelpathi) |>
+  # group and check that we have the outlet in here
+  v2_out <- group_by(v2_out, levelpathi) |>
     mutate(outlet_check = any(comid == outlet_nhdpv2_COMID))
   
-  if(sum(is.na(out$outlet_check) > 150)) stop("only a small number of mainstems should not have nhdplusv2 outlets")
+  if(sum(is.na(v2_out$outlet_check) > 150)) stop("only a small number of mainstems should not have nhdplusv2 outlets")
 
   # outlet_check can be NA or TRUE
-  if(!all(is.na(out$outlet_check) | out$outlet_check)) stop("all levelpaths should have the outlet in them")
+  if(!all(is.na(v2_out$outlet_check) | v2_out$outlet_check)) stop("all levelpaths should have the outlet in them")
   
-  out <- select(ungroup(out), uri, comid)  
-
-  out <- distinct(out) |>
+  v2_out <- select(ungroup(v2_out), uri, comid) |>
+    distinct() |>
     filter(!is.na(comid))
 
-  stopifnot(!any(duplicated(out$comid)))
+  stopifnot(!any(duplicated(v2_out$comid)))
 
-  readr::write_csv(out, "out/nhdpv2_lookup.csv")
-
-  out <- sf::st_drop_geometry(mainstems) |>
-    filter(!superseded) |>
+  #### HR
+  # initialize with mainstems
+  hr_out <- sf::st_drop_geometry(mainstems) |>
     select(uri, head_nhdplushr_id, outlet_nhdplushr_id) |>
     distinct() |>
     # first join to get levelpath
@@ -64,60 +76,75 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
     ) |>
     filter(!is.na(levelpath))
 
+  stopifnot(!any(duplicated(hr_out$nhdplushr_permid)))
+
   get_dups <- function (x, col) {
     x[x[[col]] %in% x[[col]][duplicated(x[[col]])], ]
   }
 
-  # If a mainstem is only part of a levelpath we will have duplication
+  # If a mainstem is only *part* of a levelpath we will have duplication
   # for dups -- we need a split levelpath approach
-  dups <- get_dups(out, "levelpath")
+  dups <- get_dups(hr_out, "levelpath")
 
+  dup_uri <- unique(dups$uri)
+
+  # split on level path -- for each, we need to break into two
   splits <- group_by(dups, levelpath) |>
     group_split()
 
-  assign_uri <- function(x, splits, hr_ref_net) {
-
-    message(x)
-
-    x <- splits[[x]]
+  # need to assign to individual features
+  assign_uri <- function(p, splits, hr_ref_net) {
+    # debug
+    # message(p)
+    ms <- splits[[p]]
 
     suppressWarnings(
-    y <- filter(hr_ref_net, levelpath %in% x$levelpath) |>
+    path <- filter(hr_ref_net, levelpath %in% ms$levelpath) |>
       hydroloom::sort_network() # sorted top to bottom
     )
 
-    y$uri <- NA_character_
+    path$uri <- NA_character_
     
-    for (i in seq_len(nrow(x))) {
-      head_idx <- which(y$nhdplushr_id == x$head_nhdplushr_id[i])
-      outlet_idx <- which(y$nhdplushr_id == x$outlet_nhdplushr_id[i])
+    for (i in seq_len(nrow(ms))) {
+      head_idx <- which(path$nhdplushr_id == ms$head_nhdplushr_id[i])
+      outlet_idx <- which(path$nhdplushr_id == ms$outlet_nhdplushr_id[i])
 
       if(length(outlet_idx) == 0) stop()
 
-      y$uri[head_idx:outlet_idx] <- x$uri[i]
+      path$uri[head_idx:outlet_idx] <- ms$uri[i]
+      path$head_nhdplushr_id <- ms$head_nhdplushr_id[i]
+      path$outlet_nhdplushr_id <- ms$outlet_nhdplushr_id[i]
     }
     
-    y
+    path
   }
 
-  
   dup_assign <- lapply(seq_along(splits), assign_uri, splits = splits, hr_ref_net = hr_ref_net)
 
   # dup_assign gets mainstem
-  dup_assign <- bind_rows(dup_assign)
+  dup_assign <- bind_rows(dup_assign) |>
+    rename(nhdplushr_permid = permid)
 
+  stopifnot(all(dup_uri %in% dup_assign$uri))
+  stopifnot(!any(duplicated(dup_assign$nhdplushr_id)))
   stopifnot(all(dups$levelpath %in% dup_assign$levelpath))
 
-  out <- filter(out, !levelpath %in% dups$levelpath) |>
+  # hr_out is what has duplicated levelpath assignments per mainstem id 
+  hr_out <- filter(hr_out, !levelpath %in% dups$levelpath) |>
     # now join by levelpath to get all ids along each path
-    left_join(select(hr_ref_net, id, nhdplushr_id, nhdplushr_permid = permid, levelpath), by = "levelpath")
+    # this is for the UNDUPLICATED set
+    left_join(select(hr_ref_net, id, nhdplushr_id, nhdplushr_permid = permid, levelpath), by = "levelpath") |>
+    bind_rows(dup_assign)
+  
+  stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
+  stopifnot(!any(duplicated(hr_out$nhdplushr_permid)))
 
-  out <- group_by(out, levelpath) |>
+  hr_out <- group_by(hr_out, levelpath) |>
     mutate(outlet_check = any(nhdplushr_id == outlet_nhdplushr_id))
 
   # expect that all outlet checks are NA or TRUE
   # if not, we need to find the correct outlet from ref_net
-  tofix <- unique(out$levelpath[!out$outlet_check])
+  tofix <- unique(hr_out$levelpath[!hr_out$outlet_check])
 
   # If this is more than this we need to look into it
   stopifnot(length(tofix) < 700)
@@ -126,6 +153,7 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
   ref_net_hr <- filter(ref_net, source == "nhdphr")
   ref_net_hr <- hydroloom::add_topo_sort(ref_net_hr)
 
+  # use the sort to grab the outlet feature
   outlets <- dplyr::select(sf::st_drop_geometry(ref_net_hr), id, topo_sort, levelpath) |>
     filter(levelpath %in% tofix) |>
     group_by(levelpath) |>
@@ -135,20 +163,57 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
     select(outlet_nhdplushr_id = nhdplushr_id, levelpath)
 
   # update outlet_nhdplushr_id for tofix levelpaths
-  out <- ungroup(out) |>
+  hr_out <- ungroup(hr_out) |>
     rows_update(outlets, by = "levelpath")
 
-  out <- group_by(out, levelpath) |>
+  stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
+
+  hr_out <- group_by(hr_out, levelpath) |>
     mutate(outlet_check = any(nhdplushr_id == outlet_nhdplushr_id))
 
-  stopifnot(!any(is.na(out$outlet_check)))
+  stopifnot(!any(is.na(hr_out$outlet_check)))
 
   # want to make sure that outlet_check is TRUE or NA for all groups
-  stopifnot(all(out$outlet_check))
+  stopifnot(all(hr_out$outlet_check))
 
-  out <- select(ungroup(out), uri, nhdplushr_permid, nhdplushr_id)
+  hr_out <- select(ungroup(hr_out), uri, nhdplushr_permid, nhdplushr_id)
 
-  readr::write_csv(out, "out/nhdphr_lookup.csv")
+  # uses "both" from above to find cross-domain mainstems
+  # they already have a reference mainstem assignment so can just bind
+  hr_portion <- ref_net |>
+    sf::st_drop_geometry() |>
+    filter(levelpath %in% both$levelpath & source == "nhdphr") |>
+    select(uri = reference_mainstem, nhdplushr_id = id) |>
+    mutate(nhdplushr_id = gsub("nhdphr-", "", nhdplushr_id)) |>
+    # get permid in here too
+    left_join(distinct(select(hr_net, id, nhdplushr_permid = permid)), by = c("nhdplushr_id" = "id")) |>
+    distinct()
+
+  hr_out <- filter(hr_out, !nhdplushr_id %in% hr_portion$nhdplushr_id)
+
+  stopifnot(!any(hr_portion$nhdplushr_id %in% hr_out$nhdplushr_id))
+  stopifnot(!any(duplicated(hr_portion$nhdplushr_id)))
+
+  hr_out <- bind_rows(hr_out, hr_portion)
+  
+  stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
+  
+  v2_portion <- ref_net |>
+    sf::st_drop_geometry() |>
+    filter(levelpath %in% both$levelpath & source == "nhdpv2") |>
+    select(uri = reference_mainstem, comid = id) |>
+    mutate(comid = as.numeric(gsub("nhdpv2-", "", comid))) |>
+    distinct() |>
+    filter(!comid %in% v2_out$comid)
+
+  stopifnot(!any(v2_portion$comid %in% v2_out$comid))
+
+  v2_out <- bind_rows(v2_out, v2_portion)
+
+  stopifnot(all(mainstems$uri %in% c(hr_out$uri, v2_out$uri)))
+
+  readr::write_csv(v2_out, "out/nhdpv2_lookup.csv")
+  readr::write_csv(hr_out, "out/nhdphr_lookup.csv")
 
   "out/nhdpv2_lookup.csv"
 }

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -357,7 +357,7 @@ assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
 
   path_fixes_df <- distinct(path_fixes_df)
 
-  stopifnot(any(duplicated(path_fixes_df$nhdplushr_id)))
+  stopifnot(!any(duplicated(path_fixes_df$nhdplushr_id)))
 
   # expect some but not all
   stopifnot(any(path_fixes_df$id %in% out$id))
@@ -382,11 +382,6 @@ assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
      by = "id"
     ) |>
     distinct()
-
-  # TODO check after #
-  if(sum(is.na(out$nhdplushr_id)) < 5) { # this will likely be fixed but doing this as a gaurd for now
-    out <- filter(out, !is.na(nhdplushr_id))
-  }
 
   stopifnot(!any(duplicated(out$nhdplushr_id)))
   

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -355,17 +355,6 @@ assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
 
   still_missed <- path_fixes_df$uri[is.na(path_fixes_df$id)]
 
-  # TODO: get to the bottom of why these are overlapping
-  path_fixes_df <- filter(path_fixes_df, !is.na(id)) |>
-    filter(uri != "https://geoconnex.us/ref/mainstems/2636486") # busted
-
-  path_1 <- path_fixes_df$id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/878793"]
-  path_2 <- path_fixes_df$id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/412800"]
-
-  path_fixes_df$uri[path_fixes_df$id %in% path_1[path_1 %in% path_2]] <- "https://geoconnex.us/ref/mainstems/412800"
-  path_fixes_df$head_nhdplushr_id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/412800"] <- "23002800025263"
-  path_fixes_df$outlet_nhdplushr_id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/412800"] <- "23002800026353"
-
   path_fixes_df <- distinct(path_fixes_df)
 
   stopifnot(any(duplicated(path_fixes_df$nhdplushr_id)))
@@ -377,16 +366,15 @@ assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
   # expect all URIs to be present because we initialized with heads
   stopifnot(all(path_fixes_df$uri %in% out$uri))
 
+  # we need to update these -- they are where a previous assignment was wrong
   update <- select(filter(path_fixes_df, id %in% out$id), id, uri)
   
-  update$uri[update$id == "nhdphr-23002800086456"] <- "https://geoconnex.us/ref/mainstems/332734"
-
   update <- distinct(update)
 
   stopifnot(!any(duplicated(update$id)))
 
   # need to add rows and then update rows
-  out2 <- out |>
+  out <- out |>
     select(-outlet_check, -toid) |>
     bind_rows(filter(path_fixes_df, !nhdplushr_id %in% out$nhdplushr_id)) |>
     rows_update(
@@ -395,57 +383,15 @@ assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
     ) |>
     distinct()
 
-  stopifnot(!any(duplicated(out2$nhdplushr_id)))
+  # TODO check after #
+  if(sum(is.na(out$$nhdplushr_id)) < 5) { # this will likely be fixed but doing this as a gaurd for now
+    out <- filter(out, !is.na(nhdplushr_id))
+  }
+
+  stopifnot(!any(duplicated(out$nhdplushr_id)))
   
   # NA are the ones that we couldn't get above
   stopifnot(all(sort(out$uri[is.na(out$nhdplushr_id)]) == sort(still_missed)))
 
   out
-}
-
-## UNUSED
-#' Walk network to find mainstem flowlines for unmatched URIs
-#'
-#' For mainstems not resolved by levelpath or prior tracing, walks the full
-#' reference network from head to outlet to collect all flowline IDs.
-#'
-#' @param missed data.frame with uri, head_nhdplushr_id, and outlet_nhdplushr_id
-#' @param ref_net sf data.frame full reference network
-#' @return data.frame with uri, id, nhdplushr_id, levelpath columns
-#' @keywords internal
-walk_network_find_mainstem <- function(missed, ref_net) {
-
-  ref_ind <- hydroloom::make_index_ids(ref_net, mode = "to")
-
-  stopifnot(max(ref_ind$lengths) == 1)
-
-  paths <- pbapply::pblapply(
-    seq_len(nrow(missed)),
-    function(row) {
-      # needs to work for the whole network
-      head <- missed$head_nhdplushr_id[row]
-      head <- ifelse(grepl("nhdpv2", head), paste0("nhdphr-", head), head)
-      tryCatch({
-        path <- unname(unlist(
-          hydroloom:::navigate_network_dfs(
-            ref_ind,
-            head,
-            "down"
-          )
-        ))
-        out_ind <- which(path == paste0("nhdphr-", missed$outlet_nhdplushr_id[row]))
-        if (length(out_ind) != 1) stop()
-        path[1:out_ind]
-      }, error = function(e) NULL)
-    }
-  )
-
-  dplyr::tibble(
-    uri = missed$uri,
-    id = paths
-  ) |>
-    tidyr::unnest(id, keep_empty = TRUE) |>
-    filter(!is.na(id)) |>
-    mutate(nhdplushr_id = gsub("nhdphr-", "", id)) |>
-    left_join(select(hr_ref_net, id, levelpath), by = "id")
 }

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -6,7 +6,28 @@
 # tar_load(ref_net_v1)
 # tar_load(hr_net)
 
-#' writes lookups between mainstem id and various identifier systems
+#' write lookup tables for source networks
+#' 
+#' @description writes lookups between mainstem id and various identifier systems
+#' This could be done a couple ways. this has taken an approach that attempts 
+#' to match levelpath to mainstem. This works well for NHDPlus but has a lot 
+#' of edge cases for NHDPlusHR. See code comments for specifics.
+#' 
+#' The other approach would be a more naive, brute force navigation. As the
+#' code is, it surfaces a lot of complexity and has led to some important
+#' realizations. But this will likely need to be simplified in the future.
+#' 
+#' This function is mostly about its side affect (writing lookup tables)
+#' 
+#' Outputs:
+#' out/nhdphr_lookups.csv
+#' out/nhdpv2_lookups.csv
+#' 
+#' @param mainstems sf data.frame from workflow
+#' @param enhd_v3 data.frame containing enhd v3 network
+#' @param ref_net_v1 sf data.frame base network
+#' @param hr_net data.frame with nhdplushr flow network
+#' 
 write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
   enhd <- arrow::read_parquet(enhd_v3)
   ref_net <- sf::read_sf(ref_net_v1)
@@ -21,20 +42,162 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
     # get permid in here too
     left_join(distinct(select(hr_net, id, permid)), by = c("nhdplushr_id" = "id")) |>
     distinct()
-
-  # some flowlines span both data sources in reference network
-  # they all already have known reference mainstems assignments
-  both <- ref_net |>
-    sf::st_drop_geometry() |>
-    select(levelpath, source, uri = reference_mainstem) |>
-    filter(!is.na(uri)) |>
-    distinct() |>
-    group_by(uri) |>
-    filter(n() > 1)
   
   # only interested in current mainstems
   mainstems <- filter(mainstems, !superseded)
 
+  v2_out <- get_v2_lookup(mainstems, enhd)
+
+  #### HR
+  # initialize with mainstems
+  hr_out_init <- sf::st_drop_geometry(mainstems) |>
+    select(uri, head_nhdplushr_id, outlet_nhdplushr_id) |>
+    distinct()
+
+  # expect to find lookups for all where headwater and/or outlet ids in hr_out_init exist
+  # in the nhdphr portion of the reference network
+  need <- hr_out_init |>
+    filter(
+      head_nhdplushr_id %in% hr_ref_net$nhdplushr_id | 
+        outlet_nhdplushr_id %in% hr_ref_net$nhdplushr_id
+    )
+
+  ### CASE 1: duplication where one levelpath is made up of multiple mainstems
+  # If a mainstem is only *part* of a levelpath we will have duplication
+  # for dups -- we need a split levelpath approach
+  hr_out_1 <- dedup_mainstem_levelpath(hr_out_init, hr_ref_net)
+
+  stopifnot(all(!is.na(hr_out_1$id)))
+
+  stopifnot(!any(is.na(hr_out_1$uri)))
+
+  ### CASE 2: levelpath of outlet doesn't include mainstem outlet
+  # when this occurs, we need to use a more network-aware approach to build the lookups
+  # we expect to find the outlet on a downmain trace from the head.
+  hr_out_2 <- assign_mainstems_to_flowlines(hr_out_1, hr_ref_net)
+
+  stopifnot(all(!is.na(hr_out_2$id)))
+
+  stopifnot(!any(is.na(hr_out_2$uri)))
+
+  # some flowlines span both data sources in reference network
+  # they all already have known reference mainstems assignments
+  both <- sf::st_drop_geometry(ref_net) |> # the whole ref net
+    select(source, uri = reference_mainstem) |>
+    filter(uri %in% need$uri[!need$uri %in% hr_out_2$uri]) |>
+    distinct() |>
+    group_by(uri) |>
+    filter(n() > 1)
+
+  stopifnot(all(need$uri[!need$uri %in% hr_out_2$uri] %in% both$uri))
+
+  # they already have a reference mainstem assignment so can just bind
+  hr_portion <- sf::st_drop_geometry(ref_net) |>
+    filter(source == "nhdphr" & reference_mainstem %in% both$uri) |>
+    select(uri = reference_mainstem, nhdplushr_id = id) |>
+    mutate(nhdplushr_id = gsub("nhdphr-", "", nhdplushr_id)) |>
+    # get permid in here too
+    left_join(distinct(select(hr_net, id, nhdplushr_permid = permid)), by = c("nhdplushr_id" = "id")) |>
+    distinct()
+
+  stopifnot(!any(hr_portion$nhdplushr_id %in% hr_out_2$nhdplushr_id))
+  stopifnot(all(!is.na(hr_portion$nhdplushr_id)))
+  stopifnot(!any(is.na(hr_portion$uri)))
+
+  # check that we for sure aren't making dups
+  stopifnot(!any(hr_portion$uri %in% hr_out_2$uri))
+  # and that nothing we are adding is duplicated
+  stopifnot(!any(duplicated(hr_portion$nhdplushr_id)))
+  stopifnot(!any(is.na(hr_portion$uri)))
+  
+  # can just bind
+  hr_out <- bind_rows(ungroup(hr_out_2), ungroup(hr_portion)) |>
+    select(uri, nhdplushr_permid, nhdplushr_id)
+
+  # some major rivers start and end in nhdpv2 but flow through hr
+  extras <- sf::st_drop_geometry(ref_net) |>
+    mutate(nhdplushr_id = gsub("nhdphr-", "", id)) |>
+    filter(source == "nhdphr" & !is.na(reference_mainstem) & !nhdplushr_id %in% hr_out$nhdplushr_id) |>
+    left_join(distinct(select(hr_net, id, nhdplushr_permid = permid)), by = c("nhdplushr_id" = "id")) |>
+    select(uri = reference_mainstem, nhdplushr_id, nhdplushr_permid)
+
+  stopifnot(!any(extras$nhdplushr_id %in% hr_out$nhdplushr_id))
+  stopifnot(!any(duplicated(extras$nhdplushr_id)))
+  
+  hr_out <- bind_rows(hr_out, extras)
+
+  stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
+  
+  stopifnot(all(mainstems$uri %in% c(hr_out$uri, v2_out$uri)))
+
+  stopifnot(all(!is.na(hr_out$nhdplushr_id)))
+
+  stopifnot(!any(is.na(hr_out$uri)))
+
+  readr::write_csv(v2_out, "out/nhdpv2_lookup.csv")
+  readr::write_csv(hr_out, "out/nhdphr_lookup.csv")
+
+  "out/nhdpv2_lookup.csv"
+}
+
+#' Get duplicated rows
+#'
+#' Returns all rows where the value in `col` appears more than once.
+#'
+#' @param x data.frame
+#' @param col character column name to check for duplicates
+#' @return data.frame of rows with duplicated values in `col`
+#' @keywords internal
+get_dups <- function (x, col) {
+  x[x[[col]] %in% x[[col]][duplicated(x[[col]])], ]
+}
+
+
+ #' Assign mainstem URIs to flowlines along a split levelpath
+ #'
+ #' For levelpaths shared by multiple mainstems, assigns each flowline to
+ #' the correct mainstem URI based on head/outlet positions.
+ #'
+ #' @param p integer index into `splits`
+ #' @param splits list of data.frames from `group_split` on duplicated levelpaths
+ #' @param hr_ref_net data.frame NHDPlusHR reference network
+ #' @return data.frame with `uri` assigned to each flowline
+ #' @keywords internal
+  assign_uri <- function(p, splits, hr_ref_net) {
+    # debug
+    # message(p)
+    ms <- splits[[p]]
+
+    suppressWarnings(
+    path <- filter(hr_ref_net, levelpath %in% ms$levelpath) |>
+      hydroloom::sort_network() # sorted top to bottom
+    )
+
+    path$uri <- NA_character_
+    
+    for (i in seq_len(nrow(ms))) {
+      head_idx <- which(path$nhdplushr_id == ms$head_nhdplushr_id[i])
+      outlet_idx <- which(path$nhdplushr_id == ms$outlet_nhdplushr_id[i])
+
+      if(length(outlet_idx) == 0) stop()
+
+      path$uri[head_idx:outlet_idx] <- ms$uri[i]
+      path$head_nhdplushr_id <- ms$head_nhdplushr_id[i]
+      path$outlet_nhdplushr_id <- ms$outlet_nhdplushr_id[i]
+    }
+    
+    path
+  }
+
+#' Build NHDPlusV2 COMID-to-mainstem lookup
+#'
+#' Joins mainstems to the eNHD network via levelpath to map COMIDs to mainstem URIs.
+#'
+#' @param mainstems sf data.frame of active mainstems
+#' @param enhd data.frame eNHD v3 network with comid and levelpathi columns
+#' @return data.frame with `uri` and `comid` columns
+#' @keywords internal
+get_v2_lookup <- function(mainstems, enhd) {
   # Seed our output with all the mainstems that are relevant
   v2_out <- sf::st_drop_geometry(mainstems) |>
     select(uri, head_nhdpv2_COMID, outlet_nhdpv2_COMID) |>
@@ -64,11 +227,21 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
 
   stopifnot(!any(duplicated(v2_out$comid)))
 
-  #### HR
-  # initialize with mainstems
-  hr_out <- sf::st_drop_geometry(mainstems) |>
-    select(uri, head_nhdplushr_id, outlet_nhdplushr_id) |>
-    distinct() |>
+  v2_out
+}
+
+#' Deduplicate mainstem-levelpath assignments
+#'
+#' Resolves cases where one levelpath contains multiple mainstems by splitting
+#' and assigning flowlines to the correct mainstem.
+#'
+#' @param hr_out_init data.frame initial HR output with potential duplicates
+#' @param hr_ref_net data.frame NHDPlusHR reference network
+#' @return data.frame with deduplicated mainstem assignments
+#' @keywords internal
+dedup_mainstem_levelpath <- function(hr_out_init, hr_ref_net) {
+
+  hr_out <- hr_out_init |>
     # first join to get levelpath
     left_join(
       select(hr_ref_net, nhdplushr_id, levelpath), 
@@ -78,12 +251,6 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
 
   stopifnot(!any(duplicated(hr_out$nhdplushr_permid)))
 
-  get_dups <- function (x, col) {
-    x[x[[col]] %in% x[[col]][duplicated(x[[col]])], ]
-  }
-
-  # If a mainstem is only *part* of a levelpath we will have duplication
-  # for dups -- we need a split levelpath approach
   dups <- get_dups(hr_out, "levelpath")
 
   dup_uri <- unique(dups$uri)
@@ -92,38 +259,13 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
   splits <- group_by(dups, levelpath) |>
     group_split()
 
-  # need to assign to individual features
-  assign_uri <- function(p, splits, hr_ref_net) {
-    # debug
-    # message(p)
-    ms <- splits[[p]]
-
-    suppressWarnings(
-    path <- filter(hr_ref_net, levelpath %in% ms$levelpath) |>
-      hydroloom::sort_network() # sorted top to bottom
-    )
-
-    path$uri <- NA_character_
-    
-    for (i in seq_len(nrow(ms))) {
-      head_idx <- which(path$nhdplushr_id == ms$head_nhdplushr_id[i])
-      outlet_idx <- which(path$nhdplushr_id == ms$outlet_nhdplushr_id[i])
-
-      if(length(outlet_idx) == 0) stop()
-
-      path$uri[head_idx:outlet_idx] <- ms$uri[i]
-      path$head_nhdplushr_id <- ms$head_nhdplushr_id[i]
-      path$outlet_nhdplushr_id <- ms$outlet_nhdplushr_id[i]
-    }
-    
-    path
-  }
-
+  # assign uri defined elsewhere
   dup_assign <- lapply(seq_along(splits), assign_uri, splits = splits, hr_ref_net = hr_ref_net)
 
   # dup_assign gets mainstem
   dup_assign <- bind_rows(dup_assign) |>
-    rename(nhdplushr_permid = permid)
+    rename(nhdplushr_permid = permid) |>
+    filter(!is.na(uri))
 
   stopifnot(all(dup_uri %in% dup_assign$uri))
   stopifnot(!any(duplicated(dup_assign$nhdplushr_id)))
@@ -139,81 +281,171 @@ write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
   stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
   stopifnot(!any(duplicated(hr_out$nhdplushr_permid)))
 
-  hr_out <- group_by(hr_out, levelpath) |>
+  hr_out
+}
+
+
+#' Assign mainstems to flowlines via downstream tracing
+#'
+#' Handles cases where the mainstem outlet is not on the same levelpath as the
+#' head by tracing downstream through the network to find the correct path.
+#'
+#' @param hr_out_1 data.frame current HR output with some unresolved outlets
+#' @param hr_ref_net data.frame NHDPlusHR reference network
+#' @return data.frame with corrected mainstem-to-flowline assignments
+#' @keywords internal
+assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
+  # checks if the outlet is in the levelpath
+  ## could check if it is the outlet of the levelpath?
+  out <- group_by(hr_out_1, levelpath) |>
     mutate(outlet_check = any(nhdplushr_id == outlet_nhdplushr_id))
+
+  # if the defined mainstem outlet isn't part of the local mainstem
+  # we need to trace downstream to find it.
 
   # expect that all outlet checks are NA or TRUE
   # if not, we need to find the correct outlet from ref_net
-  tofix <- unique(hr_out$levelpath[!hr_out$outlet_check])
-
-  # If this is more than this we need to look into it
-  stopifnot(length(tofix) < 700)
-
-  # update so the outlet is correct according to the network
-  ref_net_hr <- filter(ref_net, source == "nhdphr")
-  ref_net_hr <- hydroloom::add_topo_sort(ref_net_hr)
-
-  # use the sort to grab the outlet feature
-  outlets <- dplyr::select(sf::st_drop_geometry(ref_net_hr), id, topo_sort, levelpath) |>
-    filter(levelpath %in% tofix) |>
-    group_by(levelpath) |>
-    filter(row_number() == n()) |>
+  tofix <- filter(out, !outlet_check) |>
     ungroup() |>
-    mutate(nhdplushr_id = gsub("nhdphr-", "", id)) |>
-    select(outlet_nhdplushr_id = nhdplushr_id, levelpath)
-
-  # update outlet_nhdplushr_id for tofix levelpaths
-  hr_out <- ungroup(hr_out) |>
-    rows_update(outlets, by = "levelpath")
-
-  stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
-
-  hr_out <- group_by(hr_out, levelpath) |>
-    mutate(outlet_check = any(nhdplushr_id == outlet_nhdplushr_id))
-
-  stopifnot(!any(is.na(hr_out$outlet_check)))
-
-  # want to make sure that outlet_check is TRUE or NA for all groups
-  stopifnot(all(hr_out$outlet_check))
-
-  hr_out <- select(ungroup(hr_out), uri, nhdplushr_permid, nhdplushr_id)
-
-  # uses "both" from above to find cross-domain mainstems
-  # they already have a reference mainstem assignment so can just bind
-  hr_portion <- ref_net |>
-    sf::st_drop_geometry() |>
-    filter(levelpath %in% both$levelpath & source == "nhdphr") |>
-    select(uri = reference_mainstem, nhdplushr_id = id) |>
-    mutate(nhdplushr_id = gsub("nhdphr-", "", nhdplushr_id)) |>
-    # get permid in here too
-    left_join(distinct(select(hr_net, id, nhdplushr_permid = permid)), by = c("nhdplushr_id" = "id")) |>
+    select(uri, head_nhdplushr_id, outlet_nhdplushr_id) |>
     distinct()
 
-  hr_out <- filter(hr_out, !nhdplushr_id %in% hr_portion$nhdplushr_id)
+  # If this is more than this we need to look into it
+  stopifnot(nrow(tofix) < 700)
 
-  stopifnot(!any(hr_portion$nhdplushr_id %in% hr_out$nhdplushr_id))
-  stopifnot(!any(duplicated(hr_portion$nhdplushr_id)))
+  # update so the outlet is correct according to the network
 
-  hr_out <- bind_rows(hr_out, hr_portion)
+  # make index ids to do navigations
+  ref_ind <- hydroloom::make_index_ids(hr_ref_net, mode = "to")
   
-  stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
+  # make sure we are dendritic
+  stopifnot(max(ref_ind$lengths) == 1)
+
+  have_uri <- hr_out_1$id[!is.na(hr_out_1$uri)]
+    
+  path_fixes <- pbapply::pblapply(
+    seq_len(nrow(tofix)), 
+    function(row) {
+      tryCatch({
+        path <- unname(unlist(
+          hydroloom:::navigate_network_dfs(ref_ind, paste0("nhdphr-", tofix$head_nhdplushr_id[row]), "down")
+        ))
+        out_ind <- which(path == paste0("nhdphr-", tofix$outlet_nhdplushr_id[row]))
+        # if out isn't in the path just punt
+        if(length(out_ind) != 1) {
+
+          # the first is the one we are searching
+          # the second is the last one that isn't mapped yet on this path
+          out_ind <- which(path %in% have_uri)[2]
+
+        }
+        path[1:out_ind]
+      }, error = function(e) NULL)
+    }
+  )
+
+  path_fixes_df <- dplyr::tibble(
+    uri = tofix$uri, 
+    head_nhdplushr_id = tofix$head_nhdplushr_id, 
+    outlet_nhdplushr_id = tofix$outlet_nhdplushr_id,
+    id = path_fixes
+  ) |>
+    tidyr::unnest(id, keep_empty = TRUE) |>
+    left_join(select(hr_ref_net, id, nhdplushr_id, nhdplushr_permid = permid, levelpath), by = "id")
+
+  still_missed <- path_fixes_df$uri[is.na(path_fixes_df$id)]
+
+  # TODO: get to the bottom of why these are overlapping
+  path_fixes_df <- filter(path_fixes_df, !is.na(id)) |>
+    filter(uri != "https://geoconnex.us/ref/mainstems/2636486") # busted
+
+  path_1 <- path_fixes_df$id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/878793"]
+  path_2 <- path_fixes_df$id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/412800"]
+
+  path_fixes_df$uri[path_fixes_df$id %in% path_1[path_1 %in% path_2]] <- "https://geoconnex.us/ref/mainstems/412800"
+  path_fixes_df$head_nhdplushr_id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/412800"] <- "23002800025263"
+  path_fixes_df$outlet_nhdplushr_id[path_fixes_df$uri == "https://geoconnex.us/ref/mainstems/412800"] <- "23002800026353"
+
+  path_fixes_df <- distinct(path_fixes_df)
+
+  stopifnot(any(duplicated(path_fixes_df$nhdplushr_id)))
+
+  # expect some but not all
+  stopifnot(any(path_fixes_df$id %in% out$id))
+  stopifnot(!all(path_fixes_df$id %in% out$id))
+
+  # expect all URIs to be present because we initialized with heads
+  stopifnot(all(path_fixes_df$uri %in% out$uri))
+
+  update <- select(filter(path_fixes_df, id %in% out$id), id, uri)
   
-  v2_portion <- ref_net |>
-    sf::st_drop_geometry() |>
-    filter(levelpath %in% both$levelpath & source == "nhdpv2") |>
-    select(uri = reference_mainstem, comid = id) |>
-    mutate(comid = as.numeric(gsub("nhdpv2-", "", comid))) |>
-    distinct() |>
-    filter(!comid %in% v2_out$comid)
+  update$uri[update$id == "nhdphr-23002800086456"] <- "https://geoconnex.us/ref/mainstems/332734"
 
-  stopifnot(!any(v2_portion$comid %in% v2_out$comid))
+  update <- distinct(update)
 
-  v2_out <- bind_rows(v2_out, v2_portion)
+  stopifnot(!any(duplicated(update$id)))
 
-  stopifnot(all(mainstems$uri %in% c(hr_out$uri, v2_out$uri)))
+  # need to add rows and then update rows
+  out2 <- out |>
+    select(-outlet_check, -toid) |>
+    bind_rows(filter(path_fixes_df, !nhdplushr_id %in% out$nhdplushr_id)) |>
+    rows_update(
+      update,
+     by = "id"
+    ) |>
+    distinct()
 
-  readr::write_csv(v2_out, "out/nhdpv2_lookup.csv")
-  readr::write_csv(hr_out, "out/nhdphr_lookup.csv")
+  stopifnot(!any(duplicated(out2$nhdplushr_id)))
+  
+  # NA are the ones that we couldn't get above
+  stopifnot(all(sort(out$uri[is.na(out$nhdplushr_id)]) == sort(still_missed)))
 
-  "out/nhdpv2_lookup.csv"
+  out
+}
+
+## UNUSED
+#' Walk network to find mainstem flowlines for unmatched URIs
+#'
+#' For mainstems not resolved by levelpath or prior tracing, walks the full
+#' reference network from head to outlet to collect all flowline IDs.
+#'
+#' @param missed data.frame with uri, head_nhdplushr_id, and outlet_nhdplushr_id
+#' @param ref_net sf data.frame full reference network
+#' @return data.frame with uri, id, nhdplushr_id, levelpath columns
+#' @keywords internal
+walk_network_find_mainstem <- function(missed, ref_net) {
+
+  ref_ind <- hydroloom::make_index_ids(ref_net, mode = "to")
+
+  stopifnot(max(ref_ind$lengths) == 1)
+
+  paths <- pbapply::pblapply(
+    seq_len(nrow(missed)),
+    function(row) {
+      # needs to work for the whole network
+      head <- missed$head_nhdplushr_id[row]
+      head <- ifelse(grepl("nhdpv2", head), paste0("nhdphr-", head), head)
+      tryCatch({
+        path <- unname(unlist(
+          hydroloom:::navigate_network_dfs(
+            ref_ind,
+            head,
+            "down"
+          )
+        ))
+        out_ind <- which(path == paste0("nhdphr-", missed$outlet_nhdplushr_id[row]))
+        if (length(out_ind) != 1) stop()
+        path[1:out_ind]
+      }, error = function(e) NULL)
+    }
+  )
+
+  dplyr::tibble(
+    uri = missed$uri,
+    id = paths
+  ) |>
+    tidyr::unnest(id, keep_empty = TRUE) |>
+    filter(!is.na(id)) |>
+    mutate(nhdplushr_id = gsub("nhdphr-", "", id)) |>
+    left_join(select(hr_ref_net, id, levelpath), by = "id")
 }

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -384,7 +384,7 @@ assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
     distinct()
 
   # TODO check after #
-  if(sum(is.na(out$$nhdplushr_id)) < 5) { # this will likely be fixed but doing this as a gaurd for now
+  if(sum(is.na(out$nhdplushr_id)) < 5) { # this will likely be fixed but doing this as a gaurd for now
     out <- filter(out, !is.na(nhdplushr_id))
   }
 

--- a/data/review/save_new_mainstems.R
+++ b/data/review/save_new_mainstems.R
@@ -5,62 +5,24 @@ mainstems <- sf::read_sf("out/mainstems.gpkg", "mainstems")
 
 deprecated <- sf::read_sf("data/review/deprecated_v3.geojson")
 
-new <- readr::read_csv("data/review/deprecated_lookup.csv")
+new <- readr::read_csv("data/review/new_ms_updates.csv")
 
-new$head_nhdplushr_id <- as.character(new$head_nhdplushr_id)
+update <- dplyr::group_by(new, uri) |>
+  dplyr::summarise(new_mainstemid = paste0("['", paste(new_mainstem, collapse = "', '"), "']"))
 
-all_hr_ids <- readr::read_csv("../../data/final_hr/permid_to_nhdplusid.csv")
+mainstems <- as.data.frame(mainstems) |>
+  dplyr::rows_update(update, by = "uri") |>
+  sf::st_sf()
 
-to_swtich <- all_hr_ids[all_hr_ids$nhdphr_permid %in% mainstems$head_nhdplushr_id,]
+update <- dplyr::group_by(new, uri) |>
+  dplyr::summarise(new_mainstemid = paste(new_mainstem, collapse = "', '")) |>
+  dplyr::rename(reference_mainstem = uri) |>
+  dplyr::filter(reference_mainstem %in% deprecated$reference_mainstem)
 
-# some head_nhsplushr_ids are actually permids
-mainstems$head_nhdplushr_id[match(to_swtich$nhdphr_permid, mainstems$head_nhdplushr_id)] <- to_swtich$id
-
-to_swtich <- all_hr_ids[all_hr_ids$nhdphr_permid %in% mainstems$outlet_nhdplushr_id,]
-
-mainstems$outlet_nhdplushr_id[match(to_swtich$nhdphr_permid, mainstems$outlet_nhdplushr_id)] <- to_swtich$id
-
-# get URI of new mainstem for each of the superseded one
-new <- dplyr::left_join(new, 
-  dplyr::select(sf::st_drop_geometry(mainstems), uri, head_nhdplushr_id), 
-  by = c("head_nhdplushr_id"))
-
-# check that everything is ok with deprecated mainstems
-stopifnot(!any(duplicated(deprecated$reference_mainstem)))
-stopifnot(!any(is.na(new$uri)))
-
-match_index <- match(deprecated$reference_mainstem, mainstems$uri)
-
-replace <- mainstems[match_index,]
-
-stopifnot(all(replace$uri == deprecated$reference_mainstem))
-stopifnot(all(replace$new_mainstemid == ""))
-
-# fix penobscot encompassing
-mainstems$encompassing_mainstem_basins[mainstems$uri == "https://geoconnex.us/ref/mainstems/2386091"] <-
-  "['https://geoconnex.us/ref/mainstems/2386091']"
-
-# Record the new id for the superseded penobscot fix
-new_id <- data.frame(
-  reference_mainstem = c("https://geoconnex.us/ref/mainstems/1921673"),
-  new_mainstemid = c("https://geoconnex.us/ref/mainstems/2386091")
-)
-
-new_id <- dplyr::bind_rows(new_id, 
-  dplyr::select(new, reference_mainstem, new_mainstemid = uri))
-
-stopifnot(all(new_id$reference_mainstem %in% deprecated$reference_mainstem))
-
-new_id <- dplyr::group_by(new_id, reference_mainstem) |>
-  dplyr::summarise(new_mainstemid = list(new_mainstemid))
-
-new_id$new_mainstemid <- as.character(sapply(new_id$new_mainstemid, \(x) paste(x, collapse = ", ")))
-
-deprecated <- dplyr::left_join(deprecated, new_id, by = "reference_mainstem")
+deprecated <- as.data.frame(deprecated) |>
+  dplyr::rows_update(update, by = "reference_mainstem") |>
+  sf::st_sf()
 
 unlink("data/review/deprecated_v3_new.geojson")
 sf::write_sf(deprecated, "data/review/deprecated_v3_new.geojson")
 
-mainstems$new_mainstemid[match(new_id$reference_mainstem, mainstems$uri)] <- new_id$new_mainstemid
-
-sf::write_sf(mainstems, "out/mainstems.gpkg")


### PR DESCRIPTION
v3.2 is a patch that improves the nhdplushr_lookup.csv output and fixes several issues:

- Fix topo_sort bug related to HR representations
- Fix missing nhdplushr head/outlet entries (#18)
- Patch missing HR mainstems in lookup (#18)
- Improve handling of duplicates and cross-region lookups
- Fix major cross-domain river outlet ids (#22)
- Update nhdplushr outlet ids (#21)
- Add validation checks