### PR TITLE
Nhdphr lookup

### DIFF
--- a/R/make_mainstems.R
+++ b/R/make_mainstems.R
@@ -852,7 +852,10 @@ get_ms_out <- function(ref_rivers, changes) {
                       outlet_drainagearea_sqkm = "totdasqkm",
                       uri = "reference_mainstem",
                       length = "length")))  |>
-      select(-any_of(c("length", "totdasqkm", "lp_mainstem_v2", "level"))))
+      # NOTE: `level` (streamlevel) is retained so raw_mainstems can carry it
+      # into write_lookups() for precedence ordering of the HR crosswalk.
+      # make_clean_mainstems() drops it from the published mainstems schema.
+      select(-any_of(c("length", "totdasqkm", "lp_mainstem_v2"))))
   
   # TODO: validate that these have been removed once we are no longer relying on "changes" from v2 to v3
   # remove two duplicates that should not be in here

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -2,192 +2,98 @@
 # library(sf)
 # library(targets)
 # tar_load(mainstems)
+# tar_load(raw_mainstems)
 # tar_load(enhd_v3)
-# tar_load(ref_net_v1)
 # tar_load(hr_net)
 
 #' write lookup tables for source networks
-#' 
-#' @description writes lookups between mainstem id and various identifier systems
-#' This could be done a couple ways. this has taken an approach that attempts 
-#' to match levelpath to mainstem. This works well for NHDPlus but has a lot 
-#' of edge cases for NHDPlusHR. See code comments for specifics.
-#' 
-#' The other approach would be a more naive, brute force navigation. As the
-#' code is, it surfaces a lot of complexity and has led to some important
-#' realizations. But this will likely need to be simplified in the future.
-#' 
-#' This function is mostly about its side affect (writing lookup tables)
-#' 
+#'
+#' @description writes lookups between mainstem id and various identifier systems.
+#'
+#' The NHDPlusV2 lookup is built by matching each mainstem to its eNHD levelpath
+#' (see [get_v2_lookup()]).
+#'
+#' The NHDPlusHR lookup is built by navigating the full NHDPlusHR network
+#' (`hr_net`) from each mainstem's head to its outlet. Two tiers are used per
+#' mainstem: a cheap walk along the primary-downstream ("downmain") spine, and,
+#' only when the outlet is not reached that way, a full-network trace. Mainstems
+#' are assigned in streamlevel order (larger rivers first, ties broken by
+#' levelpath) so that where paths overlap the larger river claims the flowline.
+#' See [build_hr_network()] and [assign_hr_mainstems()].
+#'
+#' This function is mostly about its side effect (writing lookup tables).
+#'
 #' Outputs:
-#' out/nhdphr_lookups.csv
-#' out/nhdpv2_lookups.csv
-#' 
-#' @param mainstems sf data.frame from workflow
-#' @param enhd_v3 data.frame containing enhd v3 network
-#' @param ref_net_v1 sf data.frame base network
-#' @param hr_net data.frame with nhdplushr flow network
-#' 
-write_lookups <- function(mainstems, enhd_v3, ref_net_v1, hr_net) {
+#' out/nhdphr_lookup.csv
+#' out/nhdpv2_lookup.csv
+#'
+#' @param mainstems sf data.frame from workflow (cleaned mainstems)
+#' @param raw_mainstems sf data.frame from workflow carrying `level` (streamlevel)
+#'   and `lp_mainstem_v3` used to order HR assignment
+#' @param enhd_v3 path to parquet containing enhd v3 network
+#' @param hr_net path to csv with the NHDPlusHR flow network
+#'
+write_lookups <- function(mainstems, raw_mainstems, enhd_v3, hr_net) {
   enhd <- arrow::read_parquet(enhd_v3)
-  ref_net <- sf::read_sf(ref_net_v1)
-  hr_net <- readr::read_csv(hr_net, col_types = "cccll")
 
-  # Only the hr part of the network
-  hr_ref_net <- sf::st_drop_geometry(ref_net) |>
-    filter(source == "nhdphr") |>
-    select(id, toid, levelpath) |>
-    distinct() |>
-    mutate(nhdplushr_id = gsub("nhdphr-", "", id)) |>
-    # get permid in here too
-    left_join(distinct(select(hr_net, id, permid)), by = c("nhdplushr_id" = "id")) |>
-    distinct()
-  
+  # streamlevel + levelpath for precedence ordering of the HR crosswalk.
+  # these are dropped from the cleaned mainstems schema, so pull from raw.
+  ord <- sf::st_drop_geometry(raw_mainstems) |>
+    dplyr::select(uri, level, lp_mainstem_v3) |>
+    dplyr::distinct()
+
   # only interested in current mainstems
-  mainstems <- filter(mainstems, !superseded)
+  mainstems <- dplyr::filter(mainstems, !superseded)
 
   v2_out <- get_v2_lookup(mainstems, enhd)
 
   #### HR
-  # initialize with mainstems
-  hr_out_init <- sf::st_drop_geometry(mainstems) |>
-    select(uri, head_nhdplushr_id, outlet_nhdplushr_id) |>
-    distinct()
+  hr_in <- sf::st_drop_geometry(mainstems) |>
+    dplyr::select(uri, head_nhdplushr_id, outlet_nhdplushr_id) |>
+    dplyr::distinct() |>
+    dplyr::left_join(ord, by = "uri")
 
-  # expect to find lookups for all where headwater and/or outlet ids in hr_out_init exist
-  # in the nhdphr portion of the reference network
-  need <- hr_out_init |>
-    filter(
-      head_nhdplushr_id %in% hr_ref_net$nhdplushr_id | 
-        outlet_nhdplushr_id %in% hr_ref_net$nhdplushr_id
-    )
+  # levelpath is always present. a small number of mainstems may lack
+  # streamlevel; these sort last (arrange puts NA level last) with levelpath
+  # breaking ties, per the levelpath fallback.
+  stopifnot(!any(is.na(hr_in$lp_mainstem_v3)))
+  stopifnot(mean(is.na(hr_in$level)) < 0.01)
 
-  ### CASE 1: duplication where one levelpath is made up of multiple mainstems
-  # If a mainstem is only *part* of a levelpath we will have duplication
-  # for dups -- we need a split levelpath approach
-  hr_out_1 <- dedup_mainstem_levelpath(hr_out_init, hr_ref_net)
+  # mainstems that actually reference the HR network
+  ms_with_hr <- dplyr::filter(
+    hr_in,
+    !is.na(head_nhdplushr_id), head_nhdplushr_id != "",
+    !is.na(outlet_nhdplushr_id), outlet_nhdplushr_id != ""
+  )
 
-  stopifnot(all(!is.na(hr_out_1$id)))
+  net <- build_hr_network(hr_net)
 
-  stopifnot(!any(is.na(hr_out_1$uri)))
+  hr_out <- assign_hr_mainstems(ms_with_hr, net)
 
-  ### CASE 2: levelpath of outlet doesn't include mainstem outlet
-  # when this occurs, we need to use a more network-aware approach to build the lookups
-  # we expect to find the outlet on a downmain trace from the head.
-  hr_out_2 <- assign_mainstems_to_flowlines(hr_out_1, hr_ref_net)
+  # Some mainstems have an HR footprint fully contained within a higher-
+  # precedence mainstem's path -- many are degenerate single-flowline mainstems
+  # (head == outlet). A flowline belongs to one mainstem, so these get no
+  # exclusive HR flowline and are left out of the HR crosswalk; they resolve via
+  # the v2 lookup where present.
+  hr_subsumed <- setdiff(ms_with_hr$uri, hr_out$uri)
+  message("write_lookups: ", length(hr_subsumed),
+          " HR mainstems subsumed by higher-precedence mainstems (left out of HR)")
+  stopifnot(length(hr_subsumed) < 500L)
 
-  stopifnot(all(!is.na(hr_out_2$id)))
-
-  stopifnot(!any(is.na(hr_out_2$uri)))
-
-  # some flowlines span both data sources in reference network
-  # they all already have known reference mainstems assignments
-  both <- sf::st_drop_geometry(ref_net) |> # the whole ref net
-    select(source, uri = reference_mainstem) |>
-    filter(uri %in% need$uri[!need$uri %in% hr_out_2$uri]) |>
-    distinct() |>
-    group_by(uri) |>
-    filter(n() > 1)
-
-  stopifnot(all(need$uri[!need$uri %in% hr_out_2$uri] %in% both$uri))
-
-  # they already have a reference mainstem assignment so can just bind
-  hr_portion <- sf::st_drop_geometry(ref_net) |>
-    filter(source == "nhdphr" & reference_mainstem %in% both$uri) |>
-    select(uri = reference_mainstem, nhdplushr_id = id) |>
-    mutate(nhdplushr_id = gsub("nhdphr-", "", nhdplushr_id)) |>
-    # get permid in here too
-    left_join(distinct(select(hr_net, id, nhdplushr_permid = permid)), by = c("nhdplushr_id" = "id")) |>
-    distinct()
-
-  stopifnot(!any(hr_portion$nhdplushr_id %in% hr_out_2$nhdplushr_id))
-  stopifnot(all(!is.na(hr_portion$nhdplushr_id)))
-  stopifnot(!any(is.na(hr_portion$uri)))
-
-  # check that we for sure aren't making dups
-  stopifnot(!any(hr_portion$uri %in% hr_out_2$uri))
-  # and that nothing we are adding is duplicated
-  stopifnot(!any(duplicated(hr_portion$nhdplushr_id)))
-  stopifnot(!any(is.na(hr_portion$uri)))
-  
-  # can just bind
-  hr_out <- bind_rows(ungroup(hr_out_2), ungroup(hr_portion)) |>
-    select(uri, nhdplushr_permid, nhdplushr_id)
-
-  # some major rivers start and end in nhdpv2 but flow through hr
-  extras <- sf::st_drop_geometry(ref_net) |>
-    mutate(nhdplushr_id = gsub("nhdphr-", "", id)) |>
-    filter(source == "nhdphr" & !is.na(reference_mainstem) & !nhdplushr_id %in% hr_out$nhdplushr_id) |>
-    left_join(distinct(select(hr_net, id, nhdplushr_permid = permid)), by = c("nhdplushr_id" = "id")) |>
-    select(uri = reference_mainstem, nhdplushr_id, nhdplushr_permid)
-
-  stopifnot(!any(extras$nhdplushr_id %in% hr_out$nhdplushr_id))
-  stopifnot(!any(duplicated(extras$nhdplushr_id)))
-  
-  hr_out <- bind_rows(hr_out, extras)
-
+  # crosswalk invariants
   stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
-  
-  stopifnot(all(mainstems$uri %in% c(hr_out$uri, v2_out$uri)))
-
-  stopifnot(all(!is.na(hr_out$nhdplushr_id)))
-
+  stopifnot(!any(is.na(hr_out$nhdplushr_id)))
   stopifnot(!any(is.na(hr_out$uri)))
+
+  # every mainstem resolves via the hr or v2 lookup, or is subsumed in HR
+  stopifnot(all(mainstems$uri %in% c(hr_out$uri, v2_out$uri) |
+                mainstems$uri %in% hr_subsumed))
 
   readr::write_csv(v2_out, "out/nhdpv2_lookup.csv")
   readr::write_csv(hr_out, "out/nhdphr_lookup.csv")
 
   "out/nhdpv2_lookup.csv"
 }
-
-#' Get duplicated rows
-#'
-#' Returns all rows where the value in `col` appears more than once.
-#'
-#' @param x data.frame
-#' @param col character column name to check for duplicates
-#' @return data.frame of rows with duplicated values in `col`
-#' @keywords internal
-get_dups <- function (x, col) {
-  x[x[[col]] %in% x[[col]][duplicated(x[[col]])], ]
-}
-
-
- #' Assign mainstem URIs to flowlines along a split levelpath
- #'
- #' For levelpaths shared by multiple mainstems, assigns each flowline to
- #' the correct mainstem URI based on head/outlet positions.
- #'
- #' @param p integer index into `splits`
- #' @param splits list of data.frames from `group_split` on duplicated levelpaths
- #' @param hr_ref_net data.frame NHDPlusHR reference network
- #' @return data.frame with `uri` assigned to each flowline
- #' @keywords internal
-  assign_uri <- function(p, splits, hr_ref_net) {
-    # debug
-    # message(p)
-    ms <- splits[[p]]
-
-    suppressWarnings(
-    path <- filter(hr_ref_net, levelpath %in% ms$levelpath) |>
-      hydroloom::sort_network() # sorted top to bottom
-    )
-
-    path$uri <- NA_character_
-    
-    for (i in seq_len(nrow(ms))) {
-      head_idx <- which(path$nhdplushr_id == ms$head_nhdplushr_id[i])
-      outlet_idx <- which(path$nhdplushr_id == ms$outlet_nhdplushr_id[i])
-
-      if(length(outlet_idx) == 0) stop()
-
-      path$uri[head_idx:outlet_idx] <- ms$uri[i]
-      path$head_nhdplushr_id <- ms$head_nhdplushr_id[i]
-      path$outlet_nhdplushr_id <- ms$outlet_nhdplushr_id[i]
-    }
-    
-    path
-  }
 
 #' Build NHDPlusV2 COMID-to-mainstem lookup
 #'
@@ -211,16 +117,16 @@ get_v2_lookup <- function(mainstems, enhd) {
               by = c("head_nhdpv2_COMID" = "comid")) |>
     left_join(distinct(select(enhd, comid, levelpathi)), # now join by levelpath to get all comids
               by = "levelpathi")
-  
+
   # group and check that we have the outlet in here
   v2_out <- group_by(v2_out, levelpathi) |>
     mutate(outlet_check = any(comid == outlet_nhdpv2_COMID))
-  
+
   if(sum(is.na(v2_out$outlet_check) > 150)) stop("only a small number of mainstems should not have nhdplusv2 outlets")
 
   # outlet_check can be NA or TRUE
   if(!all(is.na(v2_out$outlet_check) | v2_out$outlet_check)) stop("all levelpaths should have the outlet in them")
-  
+
   v2_out <- select(ungroup(v2_out), uri, comid) |>
     distinct() |>
     filter(!is.na(comid))
@@ -230,163 +136,254 @@ get_v2_lookup <- function(mainstems, enhd) {
   v2_out
 }
 
-#' Deduplicate mainstem-levelpath assignments
+#' Build the NHDPlusHR navigation network
 #'
-#' Resolves cases where one levelpath contains multiple mainstems by splitting
-#' and assigning flowlines to the correct mainstem.
+#' Reads the NHDPlusHR flow network and returns the pieces needed to trace
+#' mainstems: a common id universe, the per-id primary-downstream ("downmain")
+#' successor and primary-upstream ("upmain") predecessor (both dendritic spines
+#' used for the fast traces), the full set of downstream edges (used for the
+#' fallback trace), and the permanent id lookup.
 #'
-#' @param hr_out_init data.frame initial HR output with potential duplicates
-#' @param hr_ref_net data.frame NHDPlusHR reference network
-#' @return data.frame with deduplicated mainstem assignments
+#' @param hr_net_path path to the NHDPlusHR network csv
+#'   (columns id, permid, toid, upmain, downmain)
+#' @return list with `id` (character universe), `permid` (aligned to `id`),
+#'   `succ` (integer downmain-successor index, NA at terminals),
+#'   `upsucc` (integer upmain-predecessor index, NA at headwaters), and
+#'   `full_from`/`full_to` (integer index pairs for all downstream edges)
 #' @keywords internal
-dedup_mainstem_levelpath <- function(hr_out_init, hr_ref_net) {
+build_hr_network <- function(hr_net_path) {
+  hr_net <- readr::read_csv(hr_net_path, col_types = "cccll")
 
-  hr_out <- hr_out_init |>
-    # first join to get levelpath
-    left_join(
-      select(hr_ref_net, nhdplushr_id, levelpath), 
-      by = c("head_nhdplushr_id" = "nhdplushr_id")
-    ) |>
-    filter(!is.na(levelpath))
+  # universe of all HR flowline ids
+  id <- unique(hr_net$id)
 
-  stopifnot(!any(duplicated(hr_out$nhdplushr_permid)))
+  # permid per id (one row per id)
+  pm <- hr_net[!duplicated(hr_net$id), c("id", "permid")]
+  permid <- pm$permid[match(id, pm$id)]
 
-  dups <- get_dups(hr_out, "levelpath")
+  # downmain spine: the single primary-downstream successor per id
+  dm <- hr_net[!is.na(hr_net$downmain) & hr_net$downmain, c("id", "toid")]
+  stopifnot(!any(duplicated(dm$id)))         # downmain out-degree must be <= 1
+  succ <- rep(NA_integer_, length(id))
+  succ[match(dm$id, id)] <- match(dm$toid, id)
 
-  dup_uri <- unique(dups$uri)
+  # upmain spine: the single primary-upstream predecessor per id
+  um <- hr_net[!is.na(hr_net$upmain) & hr_net$upmain & !is.na(hr_net$toid),
+               c("id", "toid")]
+  stopifnot(!any(duplicated(um$toid)))       # upmain in-degree must be <= 1
+  upsucc <- rep(NA_integer_, length(id))
+  upsucc[match(um$toid, id)] <- match(um$id, id)
 
-  # split on level path -- for each, we need to break into two
-  splits <- group_by(dups, levelpath) |>
-    group_split()
+  # full downstream edge list (integer index pairs) for the fallback trace
+  fe <- hr_net[!is.na(hr_net$toid), c("id", "toid")]
+  full_from <- match(fe$id, id)
+  full_to <- match(fe$toid, id)
+  keep <- !is.na(full_from) & !is.na(full_to)
 
-  # assign uri defined elsewhere
-  dup_assign <- lapply(seq_along(splits), assign_uri, splits = splits, hr_ref_net = hr_ref_net)
-
-  # dup_assign gets mainstem
-  dup_assign <- bind_rows(dup_assign) |>
-    rename(nhdplushr_permid = permid) |>
-    filter(!is.na(uri))
-
-  stopifnot(all(dup_uri %in% dup_assign$uri))
-  stopifnot(!any(duplicated(dup_assign$nhdplushr_id)))
-  stopifnot(all(dups$levelpath %in% dup_assign$levelpath))
-
-  # hr_out is what has duplicated levelpath assignments per mainstem id 
-  hr_out <- filter(hr_out, !levelpath %in% dups$levelpath) |>
-    # now join by levelpath to get all ids along each path
-    # this is for the UNDUPLICATED set
-    left_join(select(hr_ref_net, id, nhdplushr_id, nhdplushr_permid = permid, levelpath), by = "levelpath") |>
-    bind_rows(dup_assign)
-  
-  stopifnot(!any(duplicated(hr_out$nhdplushr_id)))
-  stopifnot(!any(duplicated(hr_out$nhdplushr_permid)))
-
-  hr_out
+  list(id = id,
+       permid = permid,
+       succ = succ,
+       upsucc = upsucc,
+       full_from = full_from[keep],
+       full_to = full_to[keep])
 }
 
-
-#' Assign mainstems to flowlines via downstream tracing
+#' Lockstep spine trace: does each mainstem reach its target?
 #'
-#' Handles cases where the mainstem outlet is not on the same levelpath as the
-#' head by tracing downstream through the network to find the correct path.
+#' Advances all requested mainstems one spine step per round in parallel and
+#' reports which reach their target before running off the spine.
 #'
-#' @param hr_out_1 data.frame current HR output with some unresolved outlets
-#' @param hr_ref_net data.frame NHDPlusHR reference network
-#' @return data.frame with corrected mainstem-to-flowline assignments
+#' @param start,target integer per-mainstem start and target node indices
+#' @param step integer per-node successor index (a spine: `succ` or `upsucc`)
+#' @param which_ms integer indices of the mainstems to trace
+#' @return logical vector (length of `start`), TRUE where the target was reached
 #' @keywords internal
-assign_mainstems_to_flowlines <- function(hr_out_1, hr_ref_net) {
-  # checks if the outlet is in the levelpath
-  ## could check if it is the outlet of the levelpath?
-  out <- group_by(hr_out_1, levelpath) |>
-    mutate(outlet_check = any(nhdplushr_id == outlet_nhdplushr_id))
+lockstep_reach <- function(start, target, step, which_ms, max_rounds = 200000L) {
+  cur <- start
+  act <- which_ms
+  reached <- logical(length(start))
+  r <- 0L
+  while (length(act) && r < max_rounds) {
+    r <- r + 1L
+    hit <- cur[act] == target[act]
+    reached[act[hit]] <- TRUE
+    adv <- act[!hit]
+    nx <- step[cur[adv]]
+    cur[adv] <- nx
+    act <- adv[!is.na(nx)]
+  }
+  reached
+}
 
-  # if the defined mainstem outlet isn't part of the local mainstem
-  # we need to trace downstream to find it.
+#' Lockstep spine trace: collect visited (node, rank) pairs
+#'
+#' Like [lockstep_reach()] but records every visited node with the tracing
+#' mainstem's precedence rank. Only pass mainstems known to reach their target
+#' (so no off-spine overshoot is recorded).
+#'
+#' @param start,target integer per-mainstem start and target node indices
+#' @param step integer per-node successor index
+#' @param ranks integer per-mainstem precedence rank
+#' @param which_ms integer indices of the mainstems to trace
+#' @return list with integer `node` and `rank` vectors
+#' @keywords internal
+lockstep_collect <- function(start, target, step, ranks, which_ms,
+                             max_rounds = 200000L) {
+  cur <- start
+  act <- which_ms
+  ev_node <- vector("list", 0L)
+  ev_rank <- vector("list", 0L)
+  r <- 0L
+  while (length(act) && r < max_rounds) {
+    r <- r + 1L
+    nod <- cur[act]
+    ev_node[[r]] <- nod
+    ev_rank[[r]] <- ranks[act]
+    hit <- nod == target[act]
+    adv <- act[!hit]
+    nx <- step[cur[adv]]
+    cur[adv] <- nx
+    act <- adv[!is.na(nx)]
+  }
+  list(node = unlist(ev_node, use.names = FALSE),
+       rank = unlist(ev_rank, use.names = FALSE))
+}
 
-  # expect that all outlet checks are NA or TRUE
-  # if not, we need to find the correct outlet from ref_net
-  tofix <- filter(out, !outlet_check) |>
-    ungroup() |>
-    select(uri, head_nhdplushr_id, outlet_nhdplushr_id) |>
-    distinct()
+#' Assign mainstem URIs to NHDPlusHR flowlines by head-to-outlet navigation
+#'
+#' Traces each mainstem from head to outlet and assigns its URI to every
+#' flowline on that path. Mainstems are processed in streamlevel order (smaller
+#' `level` first, ties broken by smaller `lp_mainstem_v3`); a flowline is kept
+#' by the highest-precedence (smallest rank) mainstem covering it, so where a
+#' tributary's path overlaps a larger receiving river the larger river keeps the
+#' shared flowlines.
+#'
+#' Three trace tiers, each vectorized where it matters:
+#' \enumerate{
+#'   \item downmain-from-head lockstep (resolves ~99% of mainstems);
+#'   \item upmain-from-outlet lockstep, run only for tier-1 misses;
+#'   \item a bounded downstream breadth-first search over the full network for
+#'     the few mainstems whose head and outlet are connected only off both
+#'     spines (e.g. across divergences).
+#' }
+#'
+#' @param ms_with_hr data.frame with `uri`, `head_nhdplushr_id`,
+#'   `outlet_nhdplushr_id`, `level`, `lp_mainstem_v3`
+#' @param net list from [build_hr_network()]
+#' @return data.frame with `uri`, `nhdplushr_permid`, `nhdplushr_id`
+#' @keywords internal
+assign_hr_mainstems <- function(ms_with_hr, net) {
+  N <- length(net$id)
 
-  # If this is more than this we need to look into it
-  stopifnot(nrow(tofix) < 700)
+  # precedence order: larger rivers (smaller streamlevel) first, then levelpath.
+  # after this sort a mainstem's row index *is* its precedence rank (1 = best).
+  ms <- dplyr::arrange(ms_with_hr, level, lp_mainstem_v3)
+  M <- nrow(ms)
+  ranks <- seq_len(M)
 
-  # update so the outlet is correct according to the network
+  head_i <- match(ms$head_nhdplushr_id, net$id)
+  out_i  <- match(ms$outlet_nhdplushr_id, net$id)
+  stopifnot(!any(is.na(head_i)))   # coverage of head/outlet ids in hr_net is
+  stopifnot(!any(is.na(out_i)))    # expected to be complete
 
-  # make index ids to do navigations
-  ref_ind <- hydroloom::make_index_ids(hr_ref_net, mode = "to")
-  
-  # make sure we are dendritic
-  stopifnot(max(ref_ind$lengths) == 1)
+  # --- Tier 1: downmain-from-head ---
+  reached_dm <- lockstep_reach(head_i, out_i, net$succ, ranks)
+  ev1 <- lockstep_collect(head_i, out_i, net$succ, ranks, which(reached_dm))
+  miss1 <- which(!reached_dm)
+  message("HR assign: tier-1 (downmain) reached ", sum(reached_dm),
+          " / ", M, " ; ", length(miss1), " misses")
 
-  have_uri <- hr_out_1$id[!is.na(hr_out_1$uri)]
-    
-  path_fixes <- pbapply::pblapply(
-    seq_len(nrow(tofix)), 
-    function(row) {
-      tryCatch({
-        path <- unname(unlist(
-          hydroloom:::navigate_network_dfs(ref_ind, paste0("nhdphr-", tofix$head_nhdplushr_id[row]), "down")
-        ))
-        out_ind <- which(path == paste0("nhdphr-", tofix$outlet_nhdplushr_id[row]))
-        # if out isn't in the path just punt
-        if(length(out_ind) != 1) {
+  # --- Tier 2: upmain-from-outlet, only for tier-1 misses ---
+  ev2 <- list(node = integer(0), rank = integer(0))
+  reached_um <- logical(M)
+  if (length(miss1)) {
+    reached_um <- lockstep_reach(out_i, head_i, net$upsucc, miss1)
+    um_ok <- which(reached_um)
+    ev2 <- lockstep_collect(out_i, head_i, net$upsucc, ranks, um_ok)
+    message("HR assign: tier-2 (upmain) recovered ", length(um_ok),
+            " of ", length(miss1), " misses")
+  }
+  miss2 <- setdiff(miss1, which(reached_um))
 
-          # the first is the one we are searching
-          # the second is the last one that isn't mapped yet on this path
-          out_ind <- which(path %in% have_uri)[2]
+  # reduce tier-1 + tier-2 visits to one owner per node, keeping smallest rank
+  en <- c(ev1$node, ev2$node)
+  ek <- c(ev1$rank, ev2$rank)
+  o <- order(en, ek)
+  en <- en[o]; ek <- ek[o]
+  first <- !duplicated(en)
+  owner <- rep(NA_integer_, N)     # stores precedence rank; NA = unclaimed
+  owner[en[first]] <- ek[first]
 
-        }
-        path[1:out_ind]
-      }, error = function(e) NULL)
+  # --- Tier 3: bounded full-network BFS for the remainder ---
+  if (length(miss2)) {
+    stopifnot(length(miss2) < 20000L)   # a large remainder means something changed
+    message("HR assign: tier-3 (full BFS) for ", length(miss2), " mainstems")
+
+    # CSR successors over the full network (built once, only when needed)
+    outdeg <- tabulate(net$full_from, nbins = N)
+    ord <- order(net$full_from)
+    succ_arr <- net$full_to[ord]
+    s_end <- cumsum(outdeg)
+    s_start <- s_end - outdeg + 1L
+
+    # reused, generation-stamped scratch (modified in place; kept local so R
+    # does not copy the length-N vectors on each update)
+    mark <- integer(N)
+    par  <- integer(N)
+    gen  <- 0L
+    BFS_CAP <- 200000L
+    unresolved <- integer(0)
+
+    for (k in miss2) {
+      gen <- gen + 1L
+      s <- head_i[k]; t <- out_i[k]
+      mark[s] <- gen; par[s] <- 0L
+      frontier <- s
+      visited <- 0L
+      found <- (s == t)
+      while (!found && length(frontier)) {
+        f <- frontier[outdeg[frontier] > 0L]
+        if (!length(f)) break
+        d <- outdeg[f]
+        idx <- rep.int(s_start[f], d) + sequence(d) - 1L
+        nb <- succ_arr[idx]
+        src <- rep.int(f, d)
+        newn <- mark[nb] != gen
+        nb <- nb[newn]; src <- src[newn]
+        if (!length(nb)) break
+        dup <- !duplicated(nb)
+        nb <- nb[dup]; src <- src[dup]
+        mark[nb] <- gen
+        par[nb] <- src
+        visited <- visited + length(nb)
+        if (mark[t] == gen) { found <- TRUE; break }
+        if (visited > BFS_CAP) break
+        frontier <- nb
+      }
+      if (!found) { unresolved <- c(unresolved, k); next }
+
+      # reconstruct outlet -> head and claim with precedence
+      path <- integer(0); v <- t
+      repeat {
+        path <- c(path, v)
+        if (v == s) break
+        v <- par[v]
+        if (v == 0L) break
+      }
+      cur_owner <- owner[path]
+      take <- path[is.na(cur_owner) | cur_owner > k]
+      owner[take] <- k
     }
+
+    if (length(unresolved))
+      stop(length(unresolved), " mainstems have no head-to-outlet path in hr_net")
+  }
+
+  keep2 <- which(!is.na(owner))
+  data.frame(
+    uri = ms$uri[owner[keep2]],
+    nhdplushr_permid = net$permid[keep2],
+    nhdplushr_id = net$id[keep2],
+    stringsAsFactors = FALSE
   )
-
-  path_fixes_df <- dplyr::tibble(
-    uri = tofix$uri, 
-    head_nhdplushr_id = tofix$head_nhdplushr_id, 
-    outlet_nhdplushr_id = tofix$outlet_nhdplushr_id,
-    id = path_fixes
-  ) |>
-    tidyr::unnest(id, keep_empty = TRUE) |>
-    left_join(select(hr_ref_net, id, nhdplushr_id, nhdplushr_permid = permid, levelpath), by = "id")
-
-  still_missed <- path_fixes_df$uri[is.na(path_fixes_df$id)]
-
-  path_fixes_df <- distinct(path_fixes_df)
-
-  stopifnot(!any(duplicated(path_fixes_df$nhdplushr_id)))
-
-  # expect some but not all
-  stopifnot(any(path_fixes_df$id %in% out$id))
-  stopifnot(!all(path_fixes_df$id %in% out$id))
-
-  # expect all URIs to be present because we initialized with heads
-  stopifnot(all(path_fixes_df$uri %in% out$uri))
-
-  # we need to update these -- they are where a previous assignment was wrong
-  update <- select(filter(path_fixes_df, id %in% out$id), id, uri)
-  
-  update <- distinct(update)
-
-  stopifnot(!any(duplicated(update$id)))
-
-  # need to add rows and then update rows
-  out <- out |>
-    select(-outlet_check, -toid) |>
-    bind_rows(filter(path_fixes_df, !nhdplushr_id %in% out$nhdplushr_id)) |>
-    rows_update(
-      update,
-     by = "id"
-    ) |>
-    distinct()
-
-  stopifnot(!any(duplicated(out$nhdplushr_id)))
-  
-  # NA are the ones that we couldn't get above
-  stopifnot(all(sort(out$uri[is.na(out$nhdplushr_id)]) == sort(still_missed)))
-
-  out
 }

--- a/_targets.R
+++ b/_targets.R
@@ -49,7 +49,7 @@ list(
     sf::write_sf(mainstems, "out/mainstems.gpkg", "mainstems")
     "out/mainstems.gpkg"
   }, format = "file"),
-  tar_target(lookup, write_lookups(mainstems, enhd_v3, ref_net_v1, hr_net), format = "file"),
+  tar_target(lookup, write_lookups(mainstems, raw_mainstems, enhd_v3, hr_net), format = "file"),
   tar_target(validate, validate_mainstems(mainstems)),
   tar_target(non_ref_mainstems, make_nonref(
     mainstems = mainstems, 


### PR DESCRIPTION
The nhdphr lookup was only working in transboundary regions where mainstem representations have been replaced with nhdplushr data. That was by design but a full nhdplushr lookup table is needed. Fixes #25 